### PR TITLE
Add SessionStart hook to notify Web UI on /clear

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -47,6 +47,18 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$HOME/.claude/hooks/session-hook.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,11 +10,12 @@ A web-based approval UI for Claude Code permission requests. Instead of the defa
 
 ## Architecture
 
-- **approval-server.py** — Python HTTP server (port 19836) with the entire web UI embedded as a single `HTML_PAGE` triple-quoted string. Handles API endpoints (`/api/pending`, `/api/respond`, `/api/submit-prompt`, `/api/session-allow`, `/api/upload-image`, etc.) and runs a background auto-approve thread for session-level rules.
+- **approval-server.py** — Python HTTP server (port 19836) with the entire web UI embedded as a single `HTML_PAGE` triple-quoted string. Handles API endpoints (`/api/pending`, `/api/respond`, `/api/submit-prompt`, `/api/session-allow`, `/api/session-reset`, `/api/upload-image`, etc.) and runs a background auto-approve thread for session-level rules.
 - **approve-dialog.sh** — `PermissionRequest` hook. Parses tool calls, checks `settings.local.json` for pre-approved glob patterns, falls back to auto-allow if server is offline, otherwise queues a request JSON and polls for response.
 - **stop-hook.sh** — `Stop` hook. In non-tmux mode, polls for prompt submission from the web UI. In tmux mode, writes a marker and returns immediately (the UI delivers prompts via `tmux send-keys`).
 - **post-cleanup.sh** — `PostToolUse` hook. Cleans up stale request/response files after tool execution.
 - **user-prompt-hook.sh** — `UserPromptSubmit` hook. Cleans up `.prompt-waiting.json` files when user submits a prompt.
+- **session-hook.sh** — `SessionStart` hook. Notifies the approval server on session start/reset (startup, resume, clear, compact) so it can clear stale requests and session auto-allow rules.
 - **install.sh** — Installs symlinks and merges hook config into a project's `.claude/settings.json`.
 
 ## Running

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ HOOKS_DIR="$HOME/.claude/hooks"
 
 # Create symlinks in ~/.claude/hooks/ so settings.json doesn't contain user-specific paths
 mkdir -p "$HOOKS_DIR"
-for script in approve-dialog.sh post-cleanup.sh stop-hook.sh user-prompt-hook.sh; do
+for script in approve-dialog.sh post-cleanup.sh stop-hook.sh user-prompt-hook.sh session-hook.sh; do
   ln -sf "$SHARED_DIR/$script" "$HOOKS_DIR/$script"
 done
 echo "Symlinked hooks to: $HOOKS_DIR"
@@ -61,6 +61,18 @@ HOOKS_CONFIG='{
         {
           "type": "command",
           "command": "bash \"$HOME/.claude/hooks/user-prompt-hook.sh\"",
+          "timeout": 5
+        }
+      ]
+    }
+  ],
+  "SessionStart": [
+    {
+      "matcher": ".*",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash \"$HOME/.claude/hooks/session-hook.sh\"",
           "timeout": 5
         }
       ]

--- a/session-hook.sh
+++ b/session-hook.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# SessionStart hook — notifies the approval server when a session starts/resets.
+# Triggered on: startup, resume, clear, compact.
+# This allows the server to clean up stale requests and session-level auto-allow rules.
+
+INPUT=$(cat)
+
+SESSION_ID="${PPID}"
+SOURCE=$(echo "$INPUT" | jq -r '.source // "unknown"')
+
+SERVER="http://localhost:19836"
+
+# Notify the approval server (fire-and-forget; silently ignore if server is offline)
+curl -s -o /dev/null --max-time 2 \
+  -X POST "$SERVER/api/session-reset" \
+  -H "Content-Type: application/json" \
+  -d "{\"session_id\":\"${SESSION_ID}\",\"source\":\"${SOURCE}\"}" 2>/dev/null || true
+
+exit 0


### PR DESCRIPTION
## Summary
- Add `session-hook.sh` — a `SessionStart` hook that fires on startup, resume, clear, and compact
- Add `POST /api/session-reset` endpoint to the approval server that clears session auto-allow rules, denies stale pending requests, and dismisses stale prompt-waiting markers
- Register the new hook in `install.sh` (symlink + hook config)

Closes #1

## Test plan
- [ ] Start the approval server, install hooks into a project
- [ ] Trigger permission requests, click "Allow this session" on a few
- [ ] Run `/clear` in Claude Code
- [ ] Verify Web UI cards disappear and session auto-allow rules are cleared
- [ ] Verify server logs show the session reset action
- [ ] Verify server-offline fallback: stop server, run `/clear`, confirm no hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)