### PR TITLE
feat: 4-level WebUI permission rule system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,9 +17,11 @@ A web UI for Claude Code that replaces default terminal prompts with a browser-b
 
 ## Architecture
 
-- **server.py** — Python HTTP server (port 19836). Session registry, transcript incremental parser, multi-session dashboard UI, API endpoints. Background thread for zombie session cleanup. Stores volatile session-level auto-allow rules in memory (queried by hook via API).
-- **frontend.py** — Extracted HTML/CSS/JS for the dashboard UI. Imported by server.py.
-- **hook-permission-request.py** — `PermissionRequest` hook. All auto-allow decision logic is centralized here (persistent rules, smart rules, session rules via server API query). Falls back to auto-allow if server is offline. If nothing matches, queues a request JSON and polls for response.
+- **server.py** — Python HTTP server (port 19836). Session registry, transcript incremental parser, multi-session dashboard UI, API endpoints. Background thread for zombie session cleanup. Stores volatile session-level auto-allow rules in memory. Serves permission management API.
+- **frontend.py** — Extracted HTML/CSS/JS for the dashboard UI. Imported by server.py. Includes permissions management page.
+- **permission_rules.py** — 4-level auto-allow rule engine (repo/user/project/session). Pattern matching, smart rule evaluation, CRUD operations. Used by both the hook and server.
+- **auto-allow.json** — Repo-level default rules. Ships smart rules (readonly_tools, readonly_bash, project_internal_edit) as defaults.
+- **hook-permission-request.py** — `PermissionRequest` hook. Checks repo/user/project rules locally via `permission_rules.resolve()`, queries server for session rules, falls back to auto-allow if server is offline. If nothing matches, queues a request JSON and polls for response.
 - **hook-session-start.py** — `SessionStart` hook. Discovers transcript path, POSTs to `/api/session/register` with `terminal_id` (tmux pane ID on Linux, shell PID on Windows), `tmux_socket` (Linux only), cwd, and source.
 - **hook-session-end.py** — `SessionEnd` hook. POSTs to `/api/session/deregister`, local fallback cleanup of request files.
 - **platform_utils.py** — Cross-platform utilities. OS detection, temp directory paths, process tree walking (via `/proc` on Linux, `CreateToolhelp32Snapshot` on Windows), path encoding.
@@ -66,7 +68,7 @@ python3 server.py --lan    # bind 0.0.0.0 for LAN access
 
 No build step, no linter.
 
-**Testing:** `python3 -m pytest tests/ -v` — 103 tests covering core logic (platform_utils, permission rules, server state derivation). Run tests after any code change to these modules.
+**Testing:** `python3 -m pytest tests/ -v` — 112 tests covering core logic (platform_utils, permission rules, server state derivation). Run tests after any code change to these modules.
 
 **Linux/macOS deps:** Python 3, `jq` (install/uninstall scripts), Bash (install scripts). Optional: `entr` (dev.sh), `inotify-tools` (--daemon).
 
@@ -74,24 +76,46 @@ No build step, no linter.
 
 ## Key Conventions
 
-### Auto-Allow Tiers
-All auto-allow logic lives in `hook-permission-request.py`. Checked in order, first match wins:
+### Auto-Allow System
+Permission auto-allow uses a 4-level rule engine (`permission_rules.py`) plus tmux/offline fallbacks in the hook.
 
-| Tier | Name | Where it lives | Lifetime | Example |
-|------|------|---------------|----------|---------|
-| 1 | Persistent rules | `.claude/settings.local.json` | Survives restarts | `Bash(git commit:*)` |
-| 2 | Smart rules | Hook code | Always on | Read-only tools, read-only Bash, project-internal edits |
-| 3 | Tmux allowlist | Hook code | Always on | `tmux send-keys` (used by WebUI prompt delivery) |
-| 4 | Session rules | Server memory, queried via `GET /api/check-auto-allow` | Until session end/clear/restart | User clicks "Allow for session" in UI |
-| 5 | Server offline | Hook code | Fallback | Server unreachable → allow everything |
+**4-level rules** (priority: session > project > user > repo, first match wins):
 
-**Why session rules live on the server, not the hook:** The hook is a short-lived process (runs once per permission request, then exits). It has no persistent memory. Session rules need to survive across multiple hook invocations within a session, so they're stored in the server's memory and queried via API. They can't be written to a file by the hook because the server manages their lifecycle (cleared on session end, clear, zombie cleanup, pane eviction).
+| Level | Storage | Lifetime |
+|-------|---------|----------|
+| Repo | `auto-allow.json` (in webui repo) | Git tracked, ships defaults |
+| User | `~/.claude/webui-allow.json` | Survives restarts, default write target |
+| Project | `<project>/.claude/webui-allow.json` | Per-project |
+| Session | Server memory | Until session end/clear/restart |
 
-### Allow Pattern Format
-Patterns in `settings.local.json` (tier 1) use `ToolName(pattern)` format with glob matching:
-- `Bash(git commit:*)` — `:*` suffix means "starts with"
-- `Write(/some/path/*)` — directory-scoped write permission
-- `Read`, `WebFetch` — tool-level blanket allow
+Within each level, pattern rules are checked before smart rules.
+
+**Additional hook tiers** (after 4-level rules):
+- Tmux allowlist — `tmux` commands auto-allowed (for WebUI prompt delivery)
+- Session rules — queried via `GET /api/check-auto-allow` (server evaluates session-level)
+- Server offline — if server unreachable, allow everything
+
+**Why session rules live on the server, not the hook:** The hook is a short-lived process (runs once per permission request, then exits). It has no persistent memory. Session rules need to survive across multiple hook invocations within a session, so they're stored in the server's memory and queried via API.
+
+### Rule Format
+Rules use a simplified JSON format (not Claude Code's `ToolName(pattern)` format):
+```json
+{
+  "rules": [
+    {"tool": "Bash", "prefix": "git commit", "action": "allow"},
+    {"tool": "Write", "action": "allow"}
+  ],
+  "smart_rules": {
+    "readonly_tools": "allow",
+    "readonly_bash": "allow",
+    "project_internal_edit": "allow"
+  }
+}
+```
+- **Bash rules**: match by command prefix (`git commit` matches `git commit -m 'test'`)
+- **Other tools**: match by tool name only; optional `prefix` field for Write/Edit path matching
+- **Smart rules**: `"allow"` or `"deny"` — configurable per level
+- **Compound Bash**: split on `&&|;||`, ALL parts must be allowed
 
 ### Python Escape Sequences in server.py
 `HTML_PAGE` is a `"""` triple-quoted string containing inline JS. Python processes escape sequences inside it:
@@ -149,12 +173,19 @@ Queue dir: `/tmp/claude-webui` (Linux/macOS) or `%TEMP%\claude-webui` (Windows).
 | GET | `/api/sessions` | All sessions with transcript-derived state |
 | GET | `/api/session/<id>/transcript` | Parsed transcript entries |
 | GET | `/api/check-auto-allow` | Check session auto-allow rules (used by hook) |
+| GET | `/api/permissions` | Get all 4 levels of permission rules |
 | GET | `/api/pending` | Pending permission requests |
 | GET | `/api/image?path=` | Serve uploaded images |
 | POST | `/api/session/register` | Register/update session |
 | POST | `/api/session/deregister` | Deregister session |
-| POST | `/api/respond` | Approve/deny permission |
-| POST | `/api/session-allow` | Session-level auto-allow |
+| POST | `/api/respond` | Approve/deny permission (writes to user-level rules on "always") |
+| POST | `/api/session-allow` | Add session-level auto-allow rule |
+| POST | `/api/permissions/add-rule` | Add a rule to any level |
+| POST | `/api/permissions/remove-rule` | Remove a rule by index |
+| POST | `/api/permissions/update-rule` | Update a rule at index |
+| POST | `/api/permissions/move-rule` | Move a rule between levels |
+| POST | `/api/permissions/set-smart-rule` | Set a smart rule at any level |
+| POST | `/api/permissions/remove-smart-rule` | Remove a smart rule |
 | POST | `/api/send-prompt` | Send prompt via tmux/console |
 | POST | `/api/upload-image` | Upload image |
 | POST | `/api/session-reset` | Clear session auto-allow rules (legacy) |

--- a/auto-allow.json
+++ b/auto-allow.json
@@ -1,0 +1,14 @@
+{
+  "rules": [
+    {
+      "tool": "Bash",
+      "action": "allow",
+      "prefix": "git checkout"
+    }
+  ],
+  "smart_rules": {
+    "readonly_tools": "allow",
+    "readonly_bash": "allow",
+    "project_internal_edit": "allow"
+  }
+}

--- a/channel_feishu.py
+++ b/channel_feishu.py
@@ -294,7 +294,11 @@ def _build_permission_card(request_id, data):
     detail_sub = data.get("detail_sub", "")
     project_dir = data.get("project_dir", "")
     session_id = data.get("session_id", "")
-    allow_pattern = data.get("allow_pattern", "")
+    allow_rule = data.get("allow_rule", {})
+    allow_display = data.get("allow_pattern", "")
+    if not allow_display and allow_rule:
+        prefix = allow_rule.get("prefix", "")
+        allow_display = f"{allow_rule.get('tool', '')}: {prefix}" if prefix else allow_rule.get("tool", "")
 
     elements = []
 
@@ -319,10 +323,10 @@ def _build_permission_card(request_id, data):
 
     elements.append({"tag": "hr"})
 
-    if allow_pattern:
+    if allow_display:
         elements.append({
             "tag": "markdown",
-            "content": f"Pattern: `{allow_pattern}`"
+            "content": f"Rule: `{allow_display}`"
         })
 
     elements.append({
@@ -847,30 +851,24 @@ def _send_text_to_user(open_id, text):
     _client.im.v1.message.create(request)
 
 
-# ── Settings helper (for "Always Allow") ──
+# ── Permission rule helper (for "Always Allow") ──
 
-def _add_to_settings(settings_file, pattern):
-    """Add an allow pattern to settings.local.json."""
+def _save_always_allow_rule(req_data):
+    """Save allow rule(s) to user-level webui-allow.json from a permission request."""
+    import permission_rules
     try:
-        if os.path.exists(settings_file):
-            with open(settings_file) as f:
-                settings = json.load(f)
-        else:
-            settings = {"permissions": {"allow": []}}
-
-        if "permissions" not in settings:
-            settings["permissions"] = {"allow": []}
-        if "allow" not in settings["permissions"]:
-            settings["permissions"]["allow"] = []
-
-        if pattern not in settings["permissions"]["allow"]:
-            settings["permissions"]["allow"].append(pattern)
-            with open(settings_file, "w") as f:
-                json.dump(settings, f, indent=2)
-                f.write("\n")
-            print(f"[feishu] Added to allowlist: {pattern}")
-    except (json.JSONDecodeError, IOError) as e:
-        print(f"[feishu] Failed to update settings: {e}")
+        allow_rules = req_data.get("allow_rules") or []
+        if not allow_rules:
+            allow_rule = req_data.get("allow_rule")
+            if allow_rule:
+                allow_rules = [allow_rule]
+        target_path = permission_rules.user_rules_path()
+        for rule in allow_rules:
+            if isinstance(rule, dict) and rule.get("tool"):
+                permission_rules.add_rule(target_path, rule)
+                print(f"[feishu] Added rule to user-level: {rule}")
+    except Exception as e:
+        print(f"[feishu] Failed to save rule: {e}")
 
 
 def _extract_first_user_prompt(entries):
@@ -1201,15 +1199,7 @@ def _handle_permission_action(request_id, decision, value):
         return P2CardActionTriggerResponse({"toast": {"type": "error", "content": "Write failed"}})
 
     if decision == "always":
-        settings_file = req_data.get("settings_file", "")
-        if settings_file and "/.claude/" in settings_file:
-            allow_patterns = req_data.get("allow_patterns") or []
-            if not allow_patterns:
-                allow_pattern = req_data.get("allow_pattern", "")
-                if allow_pattern:
-                    allow_patterns = [allow_pattern]
-            for pattern in allow_patterns:
-                _add_to_settings(settings_file, pattern)
+        _save_always_allow_rule(req_data)
 
     # Update the permission card to show resolved state (no buttons)
     with _lock:

--- a/frontend.py
+++ b/frontend.py
@@ -741,6 +741,62 @@ HTML_PAGE = """<!DOCTYPE html>
   em { font-style: italic; color: #d1d5db; }
   a { color: #60a5fa; }
 
+  /* ── Permissions management ── */
+  .perm-level { margin-bottom: 20px; }
+  .perm-level-header {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 10px 14px; background: #1e1e3a; border-radius: 8px 8px 0 0;
+    border: 1px solid #333; cursor: pointer; user-select: none;
+  }
+  .perm-level-header:hover { background: #252548; }
+  .perm-level-title { font-weight: 700; color: #c4b5fd; font-size: 14px; }
+  .perm-level-badge { font-size: 11px; color: #888; background: #2a2a4a; padding: 2px 8px; border-radius: 10px; }
+  .perm-level-body {
+    border: 1px solid #333; border-top: none; border-radius: 0 0 8px 8px;
+    padding: 12px; background: #16162a;
+  }
+  .perm-rule-row {
+    display: flex; align-items: center; gap: 8px; padding: 6px 8px;
+    border-radius: 6px; margin-bottom: 4px;
+  }
+  .perm-rule-row:hover { background: #1e1e3a; }
+  .perm-rule-tool { font-weight: 600; color: #a78bfa; min-width: 60px; font-size: 13px; }
+  .perm-rule-prefix { color: #d1d5db; font-size: 13px; flex: 1; font-family: monospace; }
+  .perm-rule-action {
+    font-size: 11px; padding: 2px 8px; border-radius: 4px; font-weight: 600;
+  }
+  .perm-rule-action.allow { background: #16a34a33; color: #4ade80; }
+  .perm-rule-action.deny { background: #ef444433; color: #f87171; }
+  .perm-rule-actions { display: flex; gap: 4px; }
+  .perm-rule-actions button {
+    padding: 3px 8px; font-size: 11px; background: #333; color: #aaa;
+    border-radius: 4px;
+  }
+  .perm-rule-actions button:hover { background: #444; color: #fff; }
+  .perm-smart-row {
+    display: flex; align-items: center; gap: 10px; padding: 6px 8px;
+    margin-bottom: 4px;
+  }
+  .perm-smart-label { color: #d1d5db; font-size: 13px; flex: 1; }
+  .perm-smart-toggle {
+    padding: 3px 10px; font-size: 11px; border-radius: 4px; font-weight: 600; cursor: pointer;
+  }
+  .perm-smart-toggle.allow { background: #16a34a33; color: #4ade80; border: 1px solid #16a34a55; }
+  .perm-smart-toggle.deny { background: #ef444433; color: #f87171; border: 1px solid #ef444455; }
+  .perm-smart-toggle.off { background: #333; color: #666; border: 1px solid #444; }
+  .perm-add-form {
+    display: flex; gap: 6px; margin-top: 8px; align-items: center; flex-wrap: wrap;
+  }
+  .perm-add-form select, .perm-add-form input {
+    background: #1e1e3a; border: 1px solid #444; color: #ddd; border-radius: 4px;
+    padding: 4px 8px; font-size: 12px;
+  }
+  .perm-add-form input { flex: 1; min-width: 120px; }
+  .perm-add-form button {
+    padding: 4px 12px; font-size: 12px; background: #3b82f6; color: white; border-radius: 4px;
+  }
+  .perm-section-label { color: #888; font-size: 11px; text-transform: uppercase; letter-spacing: 1px; margin: 10px 0 6px; }
+
   @media (max-width: 600px) {
     .container { padding: 8px 12px; }
     .header { padding: 10px 12px; gap: 8px; }
@@ -765,6 +821,7 @@ HTML_PAGE = """<!DOCTYPE html>
 <div class="header">
   <button class="back-btn" id="backBtn" onclick="showDashboard()">Back</button>
   <h1 id="pageTitle" ondblclick="window.scrollTo({top:0,behavior:'smooth'})">Claude Sessions</h1>
+  <button class="btn-scroll-bottom" id="permissionsBtn" onclick="showPermissions()" style="display:flex;background:#4b5563">Permissions</button>
   <button class="btn-scroll-bottom" id="collapseAllBtn" onclick="collapseAll()" style="display:flex">Collapse All</button>
   <button class="btn-scroll-bottom" id="scrollBottomBtn" onclick="window.scrollTo({top:document.documentElement.scrollHeight,behavior:'smooth'})">Bottom</button>
 </div>
@@ -772,6 +829,11 @@ HTML_PAGE = """<!DOCTYPE html>
 <!-- Dashboard view -->
 <div class="container dashboard" id="dashboardView">
   <div id="sessionList"></div>
+</div>
+
+<!-- Permissions management view -->
+<div class="container" id="permissionsView" style="display:none">
+  <div id="permissionsContent"></div>
 </div>
 
 <!-- Session detail view -->
@@ -1254,9 +1316,11 @@ function openSession(sid) {
   location.hash = 'session/' + sid;
   document.getElementById('dashboardView').style.display = 'none';
   document.getElementById('detailView').style.display = 'block';
+  document.getElementById('permissionsView').style.display = 'none';
   document.getElementById('backBtn').style.display = 'flex';
   document.getElementById('scrollBottomBtn').style.display = 'flex';
   document.getElementById('collapseAllBtn').style.display = 'none';
+  document.getElementById('permissionsBtn').style.display = 'flex';
   var sessionLabel = (window._sessionSlugMap && window._sessionSlugMap[sid]) || sid;
   document.getElementById('pageTitle').textContent = titlePrefix() + sessionLabel;
   document.getElementById('transcriptView').innerHTML = '';
@@ -1275,9 +1339,11 @@ function showDashboard() {
   location.hash = '';
   document.getElementById('dashboardView').style.display = 'block';
   document.getElementById('detailView').style.display = 'none';
+  document.getElementById('permissionsView').style.display = 'none';
   document.getElementById('backBtn').style.display = 'none';
   document.getElementById('scrollBottomBtn').style.display = 'none';
   document.getElementById('collapseAllBtn').style.display = 'flex';
+  document.getElementById('permissionsBtn').style.display = 'flex';
   document.getElementById('pageTitle').textContent = titlePrefix() + 'Claude Sessions';
   document.getElementById('pageTitle').style.color = '#a78bfa';
   stopDetailPolling();
@@ -1417,44 +1483,35 @@ function renderPermCards(session) {
     if (pr.detail) html += '<div class="perm-detail">' + esc(pr.detail) + '</div>';
     if (pr.detail_sub) html += '<div class="perm-sub">' + esc(pr.detail_sub) + '</div>';
 
-    // Allow info
-    const hasMulti = pr.allow_patterns && pr.allow_patterns.length > 1;
-    if (hasMulti) {
-      html += '<div class="allow-info">"Always Allow All" will apply to: ' +
-        pr.allow_patterns.map(p => '<code>' + esc(p) + '</code>').join(', ') + '</div>';
+    // Allow info — show rule that will be saved
+    const hasMultiRules = pr.allow_rules && pr.allow_rules.length > 1;
+    if (hasMultiRules) {
+      html += '<div class="allow-info">"Always Allow All" will save: ' +
+        pr.allow_rules.map(r => '<code>' + esc(r.prefix ? r.tool + ': ' + r.prefix : r.tool) + '</code>').join(', ') + '</div>';
     } else {
-      html += '<div class="allow-info">"Always Allow" will apply to: <code>' + esc(pr.allow_pattern || '') + '</code></div>';
+      const rule = (pr.allow_rules && pr.allow_rules[0]) || pr.allow_rule || {};
+      const display = rule.prefix ? rule.tool + ': ' + rule.prefix : (rule.tool || pr.allow_pattern || '');
+      html += '<div class="allow-info">"Always Allow" will save: <code>' + esc(display) + '</code></div>';
     }
 
-    // Session-allow info for Read/Edit/Write
-    if (['Read','Edit','Write'].includes(pr.tool_name)) {
-      html += '<div class="allow-info">"Allow this session" will auto-approve all <code>' + esc(pr.tool_name) + '</code> calls in session ' + esc(String(pr.session_id)) + '</div>';
-    }
+    // Session-allow info
+    const normalizedTool = (pr.tool_name || '').replace('mcp__acp__', '');
+    html += '<div class="allow-info">"Allow this session" will auto-approve all <code>' + esc(normalizedTool) + '</code> calls this session</div>';
 
-    // Path select area for Edit/Write
-    if (['Edit','Write'].includes(pr.tool_name)) {
-      html += '<div class="path-select-area" id="path-area-' + esc(pr.id) + '" style="display:none"></div>';
-    }
-
-    // Split patterns area
-    if (hasMulti) {
+    // Split rules area (compound Bash)
+    if (hasMultiRules) {
       html += '<div class="path-select-area" id="split-area-' + esc(pr.id) + '" style="display:none"></div>';
     }
 
     html += '<div class="buttons">';
     html += '<button class="' + denyClass + '" onclick="respond(\\'' + esc(pr.id) + '\\',\\'deny\\',this)">Deny</button>';
-    if (hasMulti) {
+    if (hasMultiRules) {
       html += '<button class="btn-always" onclick="respondAlwaysAll(\\'' + esc(pr.id) + '\\',this)">Always Allow All</button>';
-      html += '<button class="btn-always" style="background:#0d9488" onclick="toggleSplitPatterns(\\'' + esc(pr.id) + '\\')">Allow Command...</button>';
+      html += '<button class="btn-always" style="background:#0d9488" onclick="toggleSplitRules(\\'' + esc(pr.id) + '\\')">Allow Command...</button>';
     } else {
       html += '<button class="btn-always" onclick="respond(\\'' + esc(pr.id) + '\\',\\'always\\',this)">Always Allow</button>';
     }
-    if (['Edit','Write'].includes(pr.tool_name)) {
-      html += '<button class="btn-allow-path" onclick="togglePathSelect(\\'' + esc(pr.id) + '\\')">Allow Path</button>';
-    }
-    if (['Read','Edit','Write'].includes(pr.tool_name)) {
-      html += '<button class="btn-session" onclick="respondSessionAllow(\\'' + esc(pr.id) + '\\',\\'' + esc(String(pr.session_id)) + '\\',\\'' + esc(pr.tool_name) + '\\',this)">Allow this session</button>';
-    }
+    html += '<button class="btn-session" onclick="respondSessionAllow(\\'' + esc(pr.id) + '\\',\\'' + esc(String(pr.session_id)) + '\\',\\'' + esc(normalizedTool) + '\\',this)">Allow this session</button>';
     html += '<button class="' + allowClass + '" onclick="respond(\\'' + esc(pr.id) + '\\',\\'allow\\',this)">Allow</button>';
     html += '</div>';
   }
@@ -1905,6 +1962,16 @@ async function respond(id, decision, btn, message) {
     const body = {id, decision};
     if (message) body.message = message;
     if (sessionId) body.session_id = sessionId;
+    // For "always" decisions, include the rule to save
+    if (decision === 'always') {
+      const res = await fetch('/api/pending');
+      const data = await res.json();
+      const req = (data.requests || []).find(r => r.id === id);
+      if (req) {
+        const rule = (req.allow_rules && req.allow_rules[0]) || req.allow_rule;
+        if (rule) body.allow_rules = [rule];
+      }
+    }
     await fetch('/api/respond', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
@@ -1912,7 +1979,7 @@ async function respond(id, decision, btn, message) {
     });
     respondedIds.add(id);
     if (currentView === 'dashboard') fetchSessions();
-    else fetchSessionDetail();
+    else if (currentView === 'detail') fetchSessionDetail();
   } catch (e) {
     if (btn) btn.textContent = 'Error';
   }
@@ -1922,20 +1989,19 @@ async function respondAlwaysAll(reqId, btn) {
   const card = btn.closest('.perm-card');
   if (card) card.querySelectorAll('button').forEach(b => b.disabled = true);
   btn.textContent = '...';
-  // Get patterns from the session data
   try {
     const res = await fetch('/api/pending');
     const data = await res.json();
     const req = (data.requests || []).find(r => r.id === reqId);
-    const patterns = (req && req.allow_patterns) || [];
+    const rules = (req && req.allow_rules) || [];
     await fetch('/api/respond', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({id: reqId, decision: 'always', allow_patterns: patterns})
+      body: JSON.stringify({id: reqId, decision: 'always', allow_rules: rules})
     });
     respondedIds.add(reqId);
     if (currentView === 'dashboard') fetchSessions();
-    else fetchSessionDetail();
+    else if (currentView === 'detail') fetchSessionDetail();
   } catch (e) {
     btn.textContent = 'Error';
   }
@@ -1988,60 +2054,32 @@ async function submitFeedback(id) {
   } catch (e) {}
 }
 
-function togglePathSelect(reqId) {
-  const area = document.getElementById('path-area-' + reqId);
-  if (!area) return;
-  if (area.style.display !== 'none') { area.style.display = 'none'; return; }
-  // Fetch request data to build path options
-  fetch('/api/pending').then(r => r.json()).then(data => {
-    const req = (data.requests || []).find(r => r.id === reqId);
-    if (!req) return;
-    const filePath = (req.tool_input && req.tool_input.file_path) || '';
-    const projectDir = req.project_dir || '';
-    const toolName = req.tool_name || 'Write';
-    if (!filePath) return;
-    const rel = projectDir && filePath.startsWith(projectDir) ? filePath.slice(projectDir.length).replace(/^\\//, '') : filePath;
-    const parts = rel.split('/').filter(Boolean);
-    const projectName = projectDir.split('/').filter(Boolean).pop() || '';
-    let html = '';
-    const rootPattern = toolName + '(' + projectDir + '/*)';
-    html += '<div class="path-option" onclick="submitPathAllow(\\'' + reqId + '\\',\\'' + esc(rootPattern) + '\\')">';
-    html += '<div class="path-label">' + esc(projectName + '/*') + '</div>';
-    html += '<div class="path-pattern">' + esc(rootPattern) + '</div></div>';
-    let cumPath = projectDir;
-    for (let i = 0; i < parts.length - 1; i++) {
-      cumPath += '/' + parts[i];
-      const displayPath = projectName + '/' + parts.slice(0, i + 1).join('/') + '/*';
-      const pattern = toolName + '(' + cumPath + '/*)';
-      html += '<div class="path-option" onclick="submitPathAllow(\\'' + reqId + '\\',\\'' + esc(pattern) + '\\')">';
-      html += '<div class="path-label">' + esc(displayPath) + '</div>';
-      html += '<div class="path-pattern">' + esc(pattern) + '</div></div>';
-    }
-    area.innerHTML = html;
-    area.style.display = 'block';
-  });
-}
-
-function toggleSplitPatterns(reqId) {
+function toggleSplitRules(reqId) {
   const area = document.getElementById('split-area-' + reqId);
   if (!area) return;
   if (area.style.display !== 'none') { area.style.display = 'none'; return; }
   fetch('/api/pending').then(r => r.json()).then(data => {
     const req = (data.requests || []).find(r => r.id === reqId);
-    if (!req || !req.allow_patterns) return;
+    if (!req || !req.allow_rules) return;
     let html = '';
-    req.allow_patterns.forEach(pat => {
-      html += '<div class="path-option" onclick="submitPathAllow(\\'' + reqId + '\\',\\'' + esc(pat) + '\\')">';
-      html += '<div class="path-label">Allow: <code>' + esc(pat) + '</code></div></div>';
+    req.allow_rules.forEach((rule, i) => {
+      const display = rule.prefix ? rule.tool + ': ' + rule.prefix : rule.tool;
+      html += '<div class="path-option" onclick="submitRuleAllow(\\'' + reqId + '\\',' + i + ')">';
+      html += '<div class="path-label">Allow: <code>' + esc(display) + '</code></div></div>';
     });
     area.innerHTML = html;
     area.style.display = 'block';
   });
 }
 
-async function submitPathAllow(reqId, pattern) {
+async function submitRuleAllow(reqId, ruleIndex) {
   try {
-    const body = {id: reqId, decision: 'always', allow_pattern: pattern};
+    const res = await fetch('/api/pending');
+    const data = await res.json();
+    const req = (data.requests || []).find(r => r.id === reqId);
+    if (!req || !req.allow_rules || !req.allow_rules[ruleIndex]) return;
+    const rule = req.allow_rules[ruleIndex];
+    const body = {id: reqId, decision: 'always', allow_rules: [rule]};
     if (currentSessionId) body.session_id = currentSessionId;
     await fetch('/api/respond', {
       method: 'POST',
@@ -2050,6 +2088,160 @@ async function submitPathAllow(reqId, pattern) {
     });
     respondedIds.add(reqId);
   } catch (e) {}
+}
+
+// ── Permissions Management ──
+
+function showPermissions() {
+  currentView = 'permissions';
+  location.hash = 'permissions';
+  document.getElementById('dashboardView').style.display = 'none';
+  document.getElementById('detailView').style.display = 'none';
+  document.getElementById('permissionsView').style.display = 'block';
+  document.getElementById('backBtn').style.display = 'flex';
+  document.getElementById('scrollBottomBtn').style.display = 'none';
+  document.getElementById('collapseAllBtn').style.display = 'none';
+  document.getElementById('permissionsBtn').style.display = 'none';
+  document.getElementById('pageTitle').textContent = 'Permission Rules';
+  document.getElementById('pageTitle').style.color = '#c4b5fd';
+  stopDetailPolling();
+  fetchPermissions();
+}
+
+async function fetchPermissions() {
+  try {
+    let url = '/api/permissions?';
+    // If we have a current session, include project_dir and session_id
+    if (currentSessionId) {
+      url += 'session_id=' + encodeURIComponent(currentSessionId) + '&';
+    }
+    // Try to get project_dir from session data
+    const sessRes = await fetch('/api/sessions');
+    const sessData = await sessRes.json();
+    const allSessions = sessData.sessions || [];
+    let projectDir = '';
+    if (currentSessionId) {
+      const sess = allSessions.find(s => String(s.session_id) === String(currentSessionId));
+      if (sess) projectDir = sess.cwd || '';
+    }
+    if (projectDir) url += 'project_dir=' + encodeURIComponent(projectDir) + '&';
+    const res = await fetch(url);
+    const data = await res.json();
+    renderPermissions(data, projectDir);
+  } catch (e) {
+    document.getElementById('permissionsContent').innerHTML = '<div style="color:#f87171;padding:20px">Failed to load permissions</div>';
+  }
+}
+
+function renderPermissions(data, projectDir) {
+  const levels = [
+    {key: 'session', label: 'Session', desc: 'Temporary (cleared on session end)', show: !!data.session},
+    {key: 'project', label: 'Project', desc: projectDir ? projectDir.split('/').pop() : 'Per-project rules', show: !!data.project},
+    {key: 'user', label: 'User', desc: '~/.claude/webui-allow.json', show: true},
+    {key: 'repo', label: 'Repo', desc: 'Default rules (shipped with WebUI)', show: true},
+  ];
+  const smartRuleNames = {
+    readonly_tools: 'Auto-allow read-only tools (Read, Glob, Grep)',
+    readonly_bash: 'Auto-allow read-only Bash commands (ls, cat, grep, git log, ...)',
+    project_internal_edit: 'Auto-allow Write/Edit to files inside project directory',
+  };
+  let html = '';
+  for (const level of levels) {
+    if (!level.show) continue;
+    const levelData = data[level.key] || {rules: [], smart_rules: {}};
+    const ruleCount = (levelData.rules || []).length;
+    const smartCount = Object.keys(levelData.smart_rules || {}).length;
+    const totalBadge = ruleCount + smartCount;
+    html += '<div class="perm-level">';
+    html += '<div class="perm-level-header" onclick="this.nextElementSibling.style.display=this.nextElementSibling.style.display===\\'none\\'?\\'block\\':\\'none\\'">';
+    html += '<span class="perm-level-title">' + esc(level.label) + ' <span style="font-weight:400;color:#888;font-size:12px">' + esc(level.desc) + '</span></span>';
+    html += '<span class="perm-level-badge">' + totalBadge + ' rule' + (totalBadge !== 1 ? 's' : '') + '</span>';
+    html += '</div>';
+    html += '<div class="perm-level-body">';
+
+    // Pattern rules
+    if (ruleCount > 0) {
+      html += '<div class="perm-section-label">Rules</div>';
+      (levelData.rules || []).forEach((rule, i) => {
+        html += '<div class="perm-rule-row">';
+        html += '<span class="perm-rule-tool">' + esc(rule.tool || '') + '</span>';
+        html += '<span class="perm-rule-prefix">' + esc(rule.prefix || '(any)') + '</span>';
+        html += '<span class="perm-rule-action ' + (rule.action || 'allow') + '">' + esc(rule.action || 'allow') + '</span>';
+        html += '<span class="perm-rule-actions">';
+        // Move buttons
+        const moveTargets = levels.filter(l => l.show && l.key !== level.key);
+        for (const t of moveTargets) {
+          html += '<button onclick="movePermRule(\\'' + level.key + '\\',' + i + ',\\'' + t.key + '\\',\\'' + esc(projectDir) + '\\')">&rarr; ' + esc(t.label) + '</button>';
+        }
+        html += '<button onclick="deletePermRule(\\'' + level.key + '\\',' + i + ',\\'' + esc(projectDir) + '\\')" style="color:#f87171">&times;</button>';
+        html += '</span>';
+        html += '</div>';
+      });
+    }
+
+    // Smart rules
+    html += '<div class="perm-section-label">Smart Rules</div>';
+    for (const [key, desc] of Object.entries(smartRuleNames)) {
+      const current = (levelData.smart_rules || {})[key] || '';
+      html += '<div class="perm-smart-row">';
+      html += '<span class="perm-smart-label">' + esc(desc) + '</span>';
+      const allowCls = current === 'allow' ? 'allow' : 'off';
+      const denyCls = current === 'deny' ? 'deny' : 'off';
+      html += '<button class="perm-smart-toggle ' + allowCls + '" onclick="setSmartRule(\\'' + level.key + '\\',\\'' + key + '\\',\\'' + (current === 'allow' ? '' : 'allow') + '\\',\\'' + esc(projectDir) + '\\')">allow</button>';
+      html += '<button class="perm-smart-toggle ' + denyCls + '" onclick="setSmartRule(\\'' + level.key + '\\',\\'' + key + '\\',\\'' + (current === 'deny' ? '' : 'deny') + '\\',\\'' + esc(projectDir) + '\\')">deny</button>';
+      html += '</div>';
+    }
+
+    // Add rule form
+    html += '<div class="perm-section-label">Add Rule</div>';
+    html += '<div class="perm-add-form" id="add-form-' + level.key + '">';
+    html += '<select id="add-tool-' + level.key + '"><option value="Bash">Bash</option><option value="Write">Write</option><option value="Edit">Edit</option><option value="WebFetch">WebFetch</option><option value="WebSearch">WebSearch</option></select>';
+    html += '<input type="text" id="add-prefix-' + level.key + '" placeholder="prefix (e.g. git commit)">';
+    html += '<select id="add-action-' + level.key + '"><option value="allow">allow</option><option value="deny">deny</option></select>';
+    html += '<button onclick="addPermRule(\\'' + level.key + '\\',\\'' + esc(projectDir) + '\\')">Add</button>';
+    html += '</div>';
+
+    html += '</div></div>';
+  }
+  document.getElementById('permissionsContent').innerHTML = html;
+}
+
+async function addPermRule(level, projectDir) {
+  const tool = document.getElementById('add-tool-' + level).value;
+  const prefix = document.getElementById('add-prefix-' + level).value.trim();
+  const action = document.getElementById('add-action-' + level).value;
+  const rule = {tool, action};
+  if (prefix) rule.prefix = prefix;
+  const body = {level, rule, project_dir: projectDir};
+  if (level === 'session' && currentSessionId) body.session_id = currentSessionId;
+  await fetch('/api/permissions/add-rule', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(body)});
+  fetchPermissions();
+}
+
+async function deletePermRule(level, index, projectDir) {
+  const body = {level, index, project_dir: projectDir};
+  if (level === 'session' && currentSessionId) body.session_id = currentSessionId;
+  await fetch('/api/permissions/remove-rule', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(body)});
+  fetchPermissions();
+}
+
+async function movePermRule(fromLevel, fromIndex, toLevel, projectDir) {
+  const body = {from_level: fromLevel, from_index: fromIndex, to_level: toLevel, project_dir: projectDir};
+  if (currentSessionId) body.session_id = currentSessionId;
+  await fetch('/api/permissions/move-rule', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(body)});
+  fetchPermissions();
+}
+
+async function setSmartRule(level, key, action, projectDir) {
+  const body = {level, key, project_dir: projectDir};
+  if (level === 'session' && currentSessionId) body.session_id = currentSessionId;
+  if (action) {
+    body.action = action;
+    await fetch('/api/permissions/set-smart-rule', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(body)});
+  } else {
+    await fetch('/api/permissions/remove-smart-rule', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(body)});
+  }
+  fetchPermissions();
 }
 
 // ── Prompt ──
@@ -2278,6 +2470,8 @@ document.getElementById('promptInput').addEventListener('paste', function(e) {
   const m = hash.match(/^#session\\/(.+)$/);
   if (m) {
     openSession(m[1]);
+  } else if (hash === '#permissions') {
+    showPermissions();
   } else {
     fetchSessions();
   }

--- a/hook-permission-request.py
+++ b/hook-permission-request.py
@@ -3,28 +3,20 @@
 PermissionRequest hook for Claude Code WebUI.
 
 Called before Claude executes a tool that requires permission.
-All auto-allow logic is centralized here; the server only stores session state.
 
 Auto-allow tiers (checked in order, first match wins):
-  1. Persistent rules   — glob patterns in .claude/settings.local.json (survive restarts)
-  2. Smart rules         — read-only tools, read-only Bash, project-internal file edits
-  3. Tmux allowlist      — tmux commands used by WebUI prompt delivery
-  4. Session rules       — per-session per-tool rules stored in server memory
-                           (set by user clicking "Allow for session" in the UI,
-                           cleared on session end/clear; queried via server API
-                           because the hook is a short-lived process with no memory)
-  5. Server offline      — if the server is unreachable, auto-allow everything
-                           so Claude Code keeps working without the WebUI
+  1. WebUI rules        — 4-level rule engine (repo/user/project levels, checked locally)
+  2. Tmux allowlist     — tmux commands used by WebUI prompt delivery
+  3. Session rules      — per-session rules stored in server memory, queried via API
+  4. Server offline     — if the server is unreachable, auto-allow everything
 
-If none of the above match, the hook writes a .request.json and polls for a
-.response.json written by the server when the user decides in the Web UI.
+If none match, the hook writes a .request.json and polls for a .response.json.
 
 Input:  JSON on stdin with { tool_name, tool_input }
 Output: JSON on stdout with { hookSpecificOutput: { decision: { behavior: "allow"|"deny" } } }
 """
 
 import atexit
-import fnmatch
 import glob
 import json
 import os
@@ -36,6 +28,7 @@ import urllib.request
 import uuid
 
 from platform_utils import get_queue_dir, find_claude_pid
+import permission_rules
 
 QUEUE_DIR = get_queue_dir()
 SERVER = "http://127.0.0.1:19836"
@@ -65,67 +58,58 @@ def deny_response(message="User denied via web UI"):
 
 
 def build_detail(tool_name, tool_input):
-    """Build detail text, detail_sub, allow_pattern, and allow_patterns per tool type."""
+    """Build detail text, detail_sub, allow_rule, and allow_rules per tool type.
+
+    allow_rule: a single rule dict for "Always Allow" (e.g. {"tool": "Bash", "prefix": "git commit", "action": "allow"})
+    allow_rules: list of rule dicts for compound Bash commands
+    """
     detail = ""
     detail_sub = ""
-    allow_pattern = tool_name
-    allow_patterns = []
+    allow_rule = {"tool": tool_name.replace("mcp__acp__", ""), "action": "allow"}
+    allow_rules = []
 
-    if tool_name in ("Bash", "mcp__acp__Bash"):
+    normalized = tool_name.replace("mcp__acp__", "")
+
+    if normalized == "Bash":
         command = tool_input.get("command", "")
         detail = command
         detail_sub = ""
-        # Parse compound commands into individual allow patterns
-        # Split on | and && to get individual commands
+        # Parse compound commands into individual rules
         parts = re.split(r'\||\&\&', command)
-        patterns = []
+        rules = []
         for part in parts:
             part = part.strip()
             if not part:
                 continue
-            first_line = part.split("\n")[0].strip()
-            tokens = first_line.split()
-            if not tokens:
+            prefix = permission_rules.extract_bash_prefix(part)
+            if not prefix:
                 continue
-            base = os.path.basename(tokens[0])
-            if not base:
-                continue
-            # Find first non-flag argument as subcommand
-            sub = ""
-            for t in tokens[1:]:
-                if not t.startswith(("-", "/", ".")):
-                    sub = t
-                    break
-            if sub:
-                pat = f"Bash({base} {sub}:*)"
-            else:
-                pat = f"Bash({base}:*)"
-            if pat not in patterns:
-                patterns.append(pat)
-        allow_patterns = patterns
-        allow_pattern = patterns[0] if patterns else f"Bash({command})"
+            rule = {"tool": "Bash", "prefix": prefix, "action": "allow"}
+            if rule not in rules:
+                rules.append(rule)
+        allow_rules = rules
+        allow_rule = rules[0] if rules else {"tool": "Bash", "action": "allow"}
 
-    elif tool_name in ("Write", "mcp__acp__Write"):
+    elif normalized == "Write":
         file_path = tool_input.get("file_path", "")
         detail = file_path
-        allow_pattern = f"Write({file_path})"
+        allow_rule = {"tool": "Write", "action": "allow"}
 
-    elif tool_name in ("Edit", "mcp__acp__Edit"):
+    elif normalized == "Edit":
         file_path = tool_input.get("file_path", "")
         old_string = tool_input.get("old_string", "")
         detail = file_path
         detail_sub = "\n".join(old_string.split("\n")[:5]) if old_string else ""
-        allow_pattern = f"Edit({file_path})"
+        allow_rule = {"tool": "Edit", "action": "allow"}
 
     elif tool_name == "ExitPlanMode":
         plan = tool_input.get("plan", "")
         detail = plan if plan else "Exit plan mode"
-        # allowedPrompts as subtitle
         allowed = tool_input.get("allowedPrompts", [])
         if allowed:
             parts = [f"{p.get('tool', '?')}: {p.get('prompt', '?')}" for p in allowed]
             detail_sub = "Requested permissions: " + ", ".join(parts)
-        allow_pattern = "ExitPlanMode"
+        allow_rule = {"tool": "ExitPlanMode", "action": "allow"}
 
     elif tool_name == "AskUserQuestion":
         questions = tool_input.get("questions", [])
@@ -137,217 +121,42 @@ def build_detail(tool_name, tool_input):
                     lines.append(f"  - {opt.get('label', '')} — {opt.get('description', '')}")
             detail = "\n".join(lines)
         else:
-            # Fallback
             detail = json.dumps(tool_input, indent=2)[:500]
-        allow_pattern = "AskUserQuestion"
+        allow_rule = {"tool": "AskUserQuestion", "action": "allow"}
 
     elif tool_name == "WebFetch":
         detail = tool_input.get("url", "")
         detail_sub = tool_input.get("prompt", "")
-        allow_pattern = "WebFetch"
+        allow_rule = {"tool": "WebFetch", "action": "allow"}
 
     elif tool_name == "WebSearch":
         detail = tool_input.get("query", "")
-        allow_pattern = "WebSearch"
+        allow_rule = {"tool": "WebSearch", "action": "allow"}
 
     else:
-        # Generic: dump tool_input
         items = [f"{k}: {v}" for k, v in list(tool_input.items())[:10]]
         detail = "\n".join(items)
-        allow_pattern = tool_name
+        allow_rule = {"tool": normalized, "action": "allow"}
 
-    return detail, detail_sub, allow_pattern, allow_patterns
-
-
-def _match_allow_pattern(tool_name, detail, pattern):
-    """Check if a single detail string matches an allow pattern."""
-    if not pattern:
-        return False
-    # Exact tool name match (e.g., "Read", "WebSearch", "Bash")
-    if pattern == tool_name:
-        return True
-    # Check ToolName(glob) pattern
-    prefix = f"{tool_name}("
-    if pattern.startswith(prefix) and pattern.endswith(")"):
-        inner = pattern[len(prefix):-1]
-        # Convert ":*" suffix to just "*" for fnmatch
-        glob_inner = inner.replace(":*", "*")
-        if fnmatch.fnmatch(detail, glob_inner):
-            return True
-    return False
+    return detail, detail_sub, allow_rule, allow_rules
 
 
-def _check_single_command(tool_name, command_str, allow_list):
-    """Check if a single (non-compound) command matches any allow pattern."""
-    command_str = command_str.strip()
-    if not command_str:
-        return True
-    # Build detail for this single command (first_line as detail)
-    first_line = command_str.split("\n")[0].strip()
-    for pattern in allow_list:
-        if _match_allow_pattern(tool_name, first_line, pattern):
-            return True
-        # Also try matching with just the base command + subcommand
-        tokens = first_line.split()
-        if tokens:
-            base = os.path.basename(tokens[0])
-            if base:
-                sub = ""
-                for t in tokens[1:]:
-                    if not t.startswith(("-", "/", ".")):
-                        sub = t
-                        break
-                # Try "base sub ..." and "base ..."
-                detail_with_sub = f"{base} {sub}" if sub else base
-                if _match_allow_pattern(tool_name, detail_with_sub, pattern):
-                    return True
-                if _match_allow_pattern(tool_name, base, pattern):
-                    return True
-    return False
-
-
-def check_auto_allow(tool_name, detail, settings_file):
-    """Check if this tool call matches any pre-approved pattern in settings.local.json."""
-    if not os.path.isfile(settings_file):
-        return False
-    try:
-        with open(settings_file) as f:
-            settings = json.load(f)
-    except (json.JSONDecodeError, IOError):
-        return False
-
-    allow_list = settings.get("permissions", {}).get("allow", [])
-    if not allow_list:
-        return False
-
-    # For Bash commands, split compound commands and check each part
-    if tool_name in ("Bash", "mcp__acp__Bash"):
-        parts = re.split(r'\||\&\&|;', detail)
-        non_empty = [p for p in parts if p.strip()]
-        if non_empty and all(
-            _check_single_command(tool_name, p, allow_list)
-            for p in non_empty
-        ):
-            return True
-        return False
-
-    # Non-Bash tools: direct match
-    for pattern in allow_list:
-        if _match_allow_pattern(tool_name, detail, pattern):
-            return True
-    return False
-
-
-# ── Smart auto-approve ──
-
-READONLY_COMMANDS = {
-    # File viewing
-    "cat", "head", "tail", "less", "more", "wc", "file", "stat", "du", "df",
-    # Directory listing
-    "ls", "tree", "find", "realpath", "dirname", "basename",
-    # Search
-    "grep", "rg", "ag", "fgrep", "egrep",
-    # Version/info
-    "echo", "printf", "date", "whoami", "hostname", "uname", "env", "printenv",
-    "which", "type", "command", "true", "false", "test",
-    # Package info (read-only)
-    "npm", "pip", "pip3", "cargo", "go", "python", "python3", "node", "ruby", "java", "javac",
-}
-
-READONLY_GIT_SUBCOMMANDS = {
-    "log", "diff", "status", "show", "branch", "tag", "remote", "stash",
-    "blame", "shortlog", "describe", "rev-parse", "rev-list", "ls-files",
-    "ls-tree", "cat-file", "config",
-}
-
-DANGEROUS_COMMANDS = {
-    "rm", "rmdir", "mv", "chmod", "chown", "chgrp", "mkfs", "dd",
-    "shutdown", "reboot", "kill", "killall", "pkill",
-    "curl", "wget",  # network access
-    "ssh", "scp", "rsync",  # remote access
-    "sudo", "su", "doas",  # privilege escalation
-}
-
-READONLY_TOOLS = {"Read", "Glob", "Grep", "mcp__acp__Read", "mcp__acp__Glob", "mcp__acp__Grep"}
-
-
-def _is_readonly_bash(command):
-    """Check if a Bash command (possibly compound) is read-only."""
-    parts = re.split(r'\||&&|\|\||;', command)
-    for part in parts:
-        part = part.strip()
-        if not part:
-            continue
-        first_line = part.split("\n")[0].strip()
-        tokens = first_line.split()
-        if not tokens:
-            continue
-        base = os.path.basename(tokens[0])
-        if not base:
-            continue
-        if base in DANGEROUS_COMMANDS:
-            return False
-        if base == "sed":
-            if "-i" in tokens or any(t.startswith("-i") for t in tokens[1:]):
-                return False
-            continue
-        if base in ("awk", "gawk", "mawk", "nawk"):
-            continue
-        if base == "git":
-            sub = ""
-            for t in tokens[1:]:
-                if not t.startswith("-"):
-                    sub = t
-                    break
-            if sub not in READONLY_GIT_SUBCOMMANDS:
-                return False
-            continue
-        if base in READONLY_COMMANDS:
-            continue
-        return False
-    return True
-
-
-def _is_project_file(file_path, project_dir):
-    """Check if a file path is within the project directory."""
-    if not file_path or not project_dir:
-        return False
-    try:
-        real_file = os.path.realpath(file_path)
-        real_cwd = os.path.realpath(project_dir)
-        return real_file.startswith(real_cwd + os.sep) or real_file == real_cwd
-    except (ValueError, OSError):
-        return False
-
-
-def check_smart_auto_approve(tool_name, tool_input, project_dir):
-    """Check if a tool call should be auto-approved by smart rules."""
-    if tool_name in READONLY_TOOLS:
-        return True
-    if tool_name in ("Bash", "mcp__acp__Bash"):
-        command = tool_input.get("command", "") if isinstance(tool_input, dict) else ""
-        if command and _is_readonly_bash(command):
-            return True
-    if tool_name in ("Write", "Edit", "mcp__acp__Write", "mcp__acp__Edit"):
-        file_path = tool_input.get("file_path", "") if isinstance(tool_input, dict) else ""
-        if _is_project_file(file_path, project_dir):
-            return True
-    return False
+def _format_rule_display(rule):
+    """Format a rule dict for display in the UI."""
+    tool = rule.get("tool", "")
+    prefix = rule.get("prefix", "")
+    if prefix:
+        return f"{tool}: {prefix}"
+    return tool
 
 
 def main():
-    # On Windows, Ctrl-C sends CTRL_C_EVENT to ALL processes in the console,
-    # including this hook subprocess.  Ignore it so we don't die mid-request
-    # (which would leave orphaned .request.json files and drop the permission
-    # response — the atexit cleanup handles graceful shutdown instead).
     import signal
     if sys.platform == "win32":
         signal.signal(signal.SIGINT, signal.SIG_IGN)
 
     os.makedirs(QUEUE_DIR, exist_ok=True)
 
-    # Read input — use binary mode to avoid encoding issues on Windows
-    # (sys.stdin defaults to locale encoding e.g. CP936, not UTF-8)
     try:
         input_data = json.loads(sys.stdin.buffer.read().decode("utf-8"))
     except (json.JSONDecodeError, ValueError):
@@ -363,47 +172,49 @@ def main():
             tool_input = {}
 
     project_dir = os.getcwd()
-    settings_file = os.path.join(project_dir, ".claude", "settings.local.json")
     session_id = input_data.get("session_id", "") or str(find_claude_pid())
 
-    # Build detail and patterns
-    detail, detail_sub, allow_pattern, allow_patterns = build_detail(tool_name, tool_input)
+    # Build detail and rules for display/storage
+    detail, detail_sub, allow_rule, allow_rules = build_detail(tool_name, tool_input)
 
     # ── Auto-allow tiers (first match wins) ──
 
-    # Tier 1: Persistent rules (settings.local.json glob patterns)
-    if check_auto_allow(tool_name, detail, settings_file):
+    # Tier 1: WebUI rules (repo + user + project levels, checked locally)
+    result = permission_rules.resolve(tool_name, tool_input, project_dir)
+    if result == "allow":
         allow_response()
+    if result == "deny":
+        deny_response("Denied by WebUI permission rule")
 
-    # Tier 2: Smart rules (read-only tools, read-only bash, project-internal edits)
-    if check_smart_auto_approve(tool_name, tool_input, project_dir):
-        allow_response()
-
-    # Tier 3: Tmux allowlist (WebUI uses tmux for prompt delivery)
+    # Tier 2: Tmux allowlist (WebUI uses tmux for prompt delivery)
     if tool_name in ("Bash", "mcp__acp__Bash"):
         command = tool_input.get("command", "").strip()
         first_token = command.split()[0] if command.split() else ""
         if os.path.basename(first_token) == "tmux":
             allow_response()
 
-    # Tier 4: Session rules (per-session per-tool, stored in server memory)
-    # Queried via API because this hook is a short-lived process with no memory.
-    # This call also doubles as the server-online check (tier 5).
+    # Tier 3: Session rules (queried via server API)
+    # This call also doubles as the server-online check (tier 4).
     try:
+        query_params = {
+            "session_id": str(session_id),
+            "tool_name": tool_name,
+            "tool_input": json.dumps(tool_input),
+        }
         req = urllib.request.Request(
-            f"{SERVER}/api/check-auto-allow?session_id={urllib.parse.quote(str(session_id))}"
-            f"&tool_name={urllib.parse.quote(tool_name)}")
+            f"{SERVER}/api/check-auto-allow?{urllib.parse.urlencode(query_params)}")
         resp = urllib.request.urlopen(req, timeout=2)
         data = json.loads(resp.read())
         if data.get("auto_allow"):
             allow_response()
+        elif data.get("auto_deny"):
+            deny_response("Denied by session rule")
     except Exception:
-        # Tier 5: Server offline — allow everything so Claude keeps working
+        # Tier 4: Server offline — allow everything so Claude keeps working
         allow_response()
 
     # Dedup: if this session already has a pending request for the same tool+input,
     # piggyback on it instead of creating a duplicate.
-    # (Claude Code may invoke the permission hook twice for the same tool call.)
     existing_rid = None
     for fpath in glob.glob(os.path.join(QUEUE_DIR, "*.request.json")):
         resp_path = fpath.replace(".request.json", ".response.json")
@@ -421,7 +232,6 @@ def main():
             continue
 
     if existing_rid:
-        # Piggyback: poll the existing request's response file
         response_file = os.path.join(QUEUE_DIR, f"{existing_rid}.response.json")
         elapsed = 0
         while elapsed < TIMEOUT:
@@ -449,7 +259,6 @@ def main():
     request_file = os.path.join(QUEUE_DIR, f"{request_id}.request.json")
     response_file = os.path.join(QUEUE_DIR, f"{request_id}.response.json")
 
-    # Clean up request file on exit
     def cleanup():
         try:
             os.remove(request_file)
@@ -457,24 +266,30 @@ def main():
             pass
     atexit.register(cleanup)
 
-    # Write request
+    # Format display strings for UI
+    if allow_rules:
+        allow_pattern = ", ".join(_format_rule_display(r) for r in allow_rules)
+        allow_patterns_display = [_format_rule_display(r) for r in allow_rules]
+    else:
+        allow_pattern = _format_rule_display(allow_rule)
+        allow_patterns_display = []
+
     request_data = {
         "id": request_id,
         "tool_name": tool_name,
         "tool_input": tool_input,
         "detail": detail,
         "detail_sub": detail_sub,
+        "allow_rule": allow_rule,
+        "allow_rules": allow_rules if allow_rules else [],
+        # Display strings for UI (human-readable)
         "allow_pattern": allow_pattern,
-        "allow_patterns": allow_patterns if allow_patterns else [],
-        "settings_file": settings_file,
+        "allow_patterns": allow_patterns_display,
         "timestamp": int(time.time()),
         "pid": os.getpid(),
         "session_id": session_id,
         "project_dir": project_dir,
     }
-    # Write atomically via temp file + os.replace to prevent the server
-    # from reading a half-written file.  os.replace works on both POSIX
-    # and Windows (unlike os.rename which fails on Windows if dest exists).
     tmp_file = request_file + ".tmp"
     with open(tmp_file, "w") as f:
         json.dump(request_data, f)
@@ -495,7 +310,6 @@ def main():
             decision = resp.get("decision", "deny")
             message = resp.get("message", "User denied via web UI")
 
-            # Cleanup
             try:
                 os.remove(request_file)
             except OSError:
@@ -504,7 +318,6 @@ def main():
                 os.remove(response_file)
             except OSError:
                 pass
-            # Unregister atexit since we cleaned up manually
             atexit.unregister(cleanup)
 
             if decision in ("allow", "always"):
@@ -515,7 +328,6 @@ def main():
         time.sleep(0.5)
         elapsed += 1
 
-    # Timeout
     try:
         os.remove(request_file)
     except OSError:

--- a/install.sh
+++ b/install.sh
@@ -118,7 +118,7 @@ install_symlinks() {
   for old_script in permission-request.py session-start.py session-end.py permission-request.sh post-tool-use.sh stop.sh user-prompt-submit.sh session-start.sh session-end.sh; do
     [ -L "$HOOKS_DIR/$old_script" ] && rm -f "$HOOKS_DIR/$old_script"
   done
-  for script in hook-permission-request.py hook-session-start.py hook-session-end.py; do
+  for script in hook-permission-request.py hook-session-start.py hook-session-end.py permission_rules.py platform_utils.py auto-allow.json; do
     ln -sf "$SHARED_DIR/$script" "$HOOKS_DIR/$script"
   done
   echo "Symlinked hooks to: $HOOKS_DIR"

--- a/permission_rules.py
+++ b/permission_rules.py
@@ -1,0 +1,373 @@
+"""
+4-level permission auto-allow rule engine for Claude Code WebUI.
+
+Levels (priority high to low): session > project > user > repo.
+Each level has pattern rules and smart rules. Within a level, rules are
+checked before smart_rules. First match across all levels wins.
+
+Rule format:
+    {"rules": [{"tool": "Bash", "prefix": "git commit", "action": "allow"}, ...],
+     "smart_rules": {"readonly_tools": "allow", "readonly_bash": "allow", ...}}
+"""
+
+import json
+import os
+import re
+
+
+# ── Path helpers ──
+
+def repo_rules_path():
+    """Path to repo-level auto-allow.json (shipped with webui code)."""
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "auto-allow.json")
+
+
+def user_rules_path():
+    """Path to user-level ~/.claude/webui-allow.json."""
+    return os.path.join(os.path.expanduser("~"), ".claude", "webui-allow.json")
+
+
+def project_rules_path(project_dir):
+    """Path to project-level <project>/.claude/webui-allow.json."""
+    return os.path.join(project_dir, ".claude", "webui-allow.json")
+
+
+# ── Loading ──
+
+_EMPTY = {"rules": [], "smart_rules": {}}
+
+
+def load_rules(path):
+    """Load rules from a JSON file. Returns empty ruleset on missing/invalid."""
+    if not path or not os.path.isfile(path):
+        return {"rules": [], "smart_rules": {}}
+    try:
+        with open(path) as f:
+            data = json.load(f)
+        rules = data.get("rules", [])
+        smart_rules = data.get("smart_rules", {})
+        return {"rules": rules, "smart_rules": smart_rules}
+    except (json.JSONDecodeError, IOError, OSError):
+        return {"rules": [], "smart_rules": {}}
+
+
+def _save_rules(path, data):
+    """Atomically write rules to a JSON file."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+    os.replace(tmp, path)
+
+
+# ── Smart rule constants (moved from hook-permission-request.py) ──
+
+READONLY_COMMANDS = {
+    "cat", "head", "tail", "less", "more", "wc", "file", "stat", "du", "df",
+    "ls", "tree", "find", "realpath", "dirname", "basename",
+    "grep", "rg", "ag", "fgrep", "egrep",
+    "echo", "printf", "date", "whoami", "hostname", "uname", "env", "printenv",
+    "which", "type", "command", "true", "false", "test",
+    "npm", "pip", "pip3", "cargo", "go", "python", "python3", "node", "ruby", "java", "javac",
+}
+
+READONLY_GIT_SUBCOMMANDS = {
+    "log", "diff", "status", "show", "branch", "tag", "remote", "stash",
+    "blame", "shortlog", "describe", "rev-parse", "rev-list", "ls-files",
+    "ls-tree", "cat-file", "config",
+}
+
+DANGEROUS_COMMANDS = {
+    "rm", "rmdir", "mv", "chmod", "chown", "chgrp", "mkfs", "dd",
+    "shutdown", "reboot", "kill", "killall", "pkill",
+    "curl", "wget",
+    "ssh", "scp", "rsync",
+    "sudo", "su", "doas",
+}
+
+READONLY_TOOLS = {"Read", "Glob", "Grep", "mcp__acp__Read", "mcp__acp__Glob", "mcp__acp__Grep"}
+
+
+# ── Bash helpers ──
+
+def is_readonly_bash(command):
+    """Check if a Bash command (possibly compound) is read-only."""
+    parts = re.split(r'\||&&|\|\||;', command)
+    for part in parts:
+        part = part.strip()
+        if not part:
+            continue
+        first_line = part.split("\n")[0].strip()
+        tokens = first_line.split()
+        if not tokens:
+            continue
+        base = os.path.basename(tokens[0])
+        if not base:
+            continue
+        if base in DANGEROUS_COMMANDS:
+            return False
+        if base == "sed":
+            if "-i" in tokens or any(t.startswith("-i") for t in tokens[1:]):
+                return False
+            continue
+        if base in ("awk", "gawk", "mawk", "nawk"):
+            continue
+        if base == "git":
+            sub = ""
+            for t in tokens[1:]:
+                if not t.startswith("-"):
+                    sub = t
+                    break
+            if sub not in READONLY_GIT_SUBCOMMANDS:
+                return False
+            continue
+        if base in READONLY_COMMANDS:
+            continue
+        return False
+    return True
+
+
+def is_project_file(file_path, project_dir):
+    """Check if a file path is within the project directory."""
+    if not file_path or not project_dir:
+        return False
+    try:
+        real_file = os.path.realpath(file_path)
+        real_cwd = os.path.realpath(project_dir)
+        return real_file.startswith(real_cwd + os.sep) or real_file == real_cwd
+    except (ValueError, OSError):
+        return False
+
+
+def extract_bash_prefix(command):
+    """Extract 'base subcommand' prefix from a single (non-compound) command.
+
+    Examples:
+        'git commit -m test' -> 'git commit'
+        'ls -la'             -> 'ls'
+        'npm install foo'    -> 'npm install'
+    """
+    command = command.strip()
+    if not command:
+        return ""
+    first_line = command.split("\n")[0].strip()
+    tokens = first_line.split()
+    if not tokens:
+        return ""
+    base = os.path.basename(tokens[0])
+    if not base:
+        return ""
+    sub = ""
+    for t in tokens[1:]:
+        if not t.startswith(("-", "/", ".")):
+            sub = t
+            break
+    if sub:
+        return f"{base} {sub}"
+    return base
+
+
+# ── Matching ──
+
+def match_rule(tool_name, tool_input, rule, project_dir=None):
+    """Check if a single rule matches the given tool call.
+
+    For Bash: matches if the command's extracted prefix starts with rule.prefix.
+    For Write/Edit with prefix: matches if file_path starts with rule.prefix (glob via fnmatch).
+    For other tools: matches on tool name only (prefix ignored).
+    """
+    rule_tool = rule.get("tool", "")
+    # Normalize MCP tool names
+    normalized = tool_name.replace("mcp__acp__", "")
+    rule_normalized = rule_tool.replace("mcp__acp__", "")
+    if normalized != rule_normalized:
+        return False
+
+    prefix = rule.get("prefix", "")
+
+    if normalized in ("Bash",):
+        if not prefix:
+            # Blanket Bash rule — matches any Bash command
+            return True
+        command = tool_input.get("command", "") if isinstance(tool_input, dict) else ""
+        # For compound commands, each part is checked separately via check_compound_bash
+        # Here we match a single command
+        cmd_prefix = extract_bash_prefix(command)
+        return cmd_prefix.startswith(prefix) if cmd_prefix else False
+
+    if normalized in ("Write", "Edit") and prefix:
+        # Path-based matching
+        import fnmatch
+        file_path = tool_input.get("file_path", "") if isinstance(tool_input, dict) else ""
+        return fnmatch.fnmatch(file_path, prefix) if file_path else False
+
+    # Non-Bash, no prefix → tool name match only
+    return True
+
+
+def _evaluate_smart_rules(tool_name, tool_input, project_dir, smart_rules):
+    """Evaluate smart rules for a tool call. Returns 'allow', 'deny', or None."""
+    normalized = tool_name.replace("mcp__acp__", "")
+
+    # readonly_tools
+    if normalized in ("Read", "Glob", "Grep"):
+        action = smart_rules.get("readonly_tools")
+        if action:
+            return action
+
+    # readonly_bash
+    if normalized == "Bash":
+        action = smart_rules.get("readonly_bash")
+        if action:
+            command = tool_input.get("command", "") if isinstance(tool_input, dict) else ""
+            if command and is_readonly_bash(command):
+                return action
+
+    # project_internal_edit
+    if normalized in ("Write", "Edit"):
+        action = smart_rules.get("project_internal_edit")
+        if action:
+            file_path = tool_input.get("file_path", "") if isinstance(tool_input, dict) else ""
+            if is_project_file(file_path, project_dir):
+                return action
+
+    return None
+
+
+def check_level(tool_name, tool_input, level_config, project_dir=None):
+    """Check one level of rules. Returns 'allow', 'deny', or None.
+
+    Checks rules first (first match wins), then smart_rules.
+    For compound Bash commands, splits and checks each part.
+    """
+    if not level_config:
+        return None
+
+    rules = level_config.get("rules", [])
+    smart_rules = level_config.get("smart_rules", {})
+
+    # Check pattern rules
+    normalized = tool_name.replace("mcp__acp__", "")
+    if normalized == "Bash" and isinstance(tool_input, dict):
+        command = tool_input.get("command", "")
+        if command:
+            result = _check_compound_bash_rules(command, rules)
+            if result is not None:
+                return result
+    else:
+        for rule in rules:
+            if match_rule(tool_name, tool_input, rule, project_dir):
+                return rule.get("action", "allow")
+
+    # Check smart rules
+    return _evaluate_smart_rules(tool_name, tool_input, project_dir, smart_rules)
+
+
+def _check_compound_bash_rules(command, rules):
+    """Check compound Bash command against rules.
+
+    Splits on &&, |, ||, ;. ALL parts must match and be allowed.
+    If any part matches a deny rule, deny the whole thing.
+    If any part has no matching rule, return None.
+    """
+    parts = re.split(r'\||&&|\|\||;', command)
+    non_empty = [p.strip() for p in parts if p.strip()]
+    if not non_empty:
+        return None
+
+    for part in non_empty:
+        part_input = {"command": part}
+        part_result = None
+        for rule in rules:
+            if match_rule("Bash", part_input, rule):
+                part_result = rule.get("action", "allow")
+                break
+        if part_result == "deny":
+            return "deny"
+        if part_result is None:
+            return None
+
+    return "allow"
+
+
+def resolve(tool_name, tool_input, project_dir, session_rules=None):
+    """Resolve permission across all 4 levels. Returns 'allow', 'deny', or None.
+
+    Priority: session > project > user > repo.
+    """
+    levels = []
+
+    # Session level (in-memory, passed in)
+    if session_rules:
+        levels.append(session_rules)
+
+    # Project level
+    if project_dir:
+        levels.append(load_rules(project_rules_path(project_dir)))
+
+    # User level
+    levels.append(load_rules(user_rules_path()))
+
+    # Repo level
+    levels.append(load_rules(repo_rules_path()))
+
+    for level_config in levels:
+        result = check_level(tool_name, tool_input, level_config, project_dir)
+        if result is not None:
+            return result
+
+    return None
+
+
+# ── CRUD operations ──
+
+def add_rule(path, rule):
+    """Add a rule to a rules file."""
+    data = load_rules(path)
+    data["rules"].append(rule)
+    _save_rules(path, data)
+
+
+def remove_rule(path, index):
+    """Remove a rule by index from a rules file."""
+    data = load_rules(path)
+    if 0 <= index < len(data["rules"]):
+        data["rules"].pop(index)
+        _save_rules(path, data)
+
+
+def update_rule(path, index, rule):
+    """Update a rule at a given index."""
+    data = load_rules(path)
+    if 0 <= index < len(data["rules"]):
+        data["rules"][index] = rule
+        _save_rules(path, data)
+
+
+def move_rule(from_path, from_index, to_path):
+    """Move a rule from one level to another."""
+    from_data = load_rules(from_path)
+    if not (0 <= from_index < len(from_data["rules"])):
+        return
+    rule = from_data["rules"].pop(from_index)
+    _save_rules(from_path, from_data)
+
+    to_data = load_rules(to_path)
+    to_data["rules"].append(rule)
+    _save_rules(to_path, to_data)
+
+
+def set_smart_rule(path, key, action):
+    """Set a smart rule in a rules file."""
+    data = load_rules(path)
+    data["smart_rules"][key] = action
+    _save_rules(path, data)
+
+
+def remove_smart_rule(path, key):
+    """Remove a smart rule from a rules file."""
+    data = load_rules(path)
+    if key in data["smart_rules"]:
+        del data["smart_rules"][key]
+        _save_rules(path, data)

--- a/server.py
+++ b/server.py
@@ -28,6 +28,7 @@ import cgi
 
 from frontend import HTML_PAGE
 from platform_utils import IS_WINDOWS, get_queue_dir, get_image_dir, is_process_alive, is_terminal_alive, find_claude_pid, get_process_children, get_process_name, encode_project_path, send_prompt, send_interrupt
+import permission_rules
 
 try:
     from channel_feishu import start_feishu_channel
@@ -72,10 +73,10 @@ def _get_session_update_lock(sid):
             _session_update_locks[sid] = threading.Lock()
         return _session_update_locks[sid]
 
-# Session-level auto-allow rules: { (session_id, tool_name): True }
+# Session-level auto-allow rules: { session_id: {"rules": [...], "smart_rules": {...}} }
 # These are volatile (in-memory only, cleared on session end/clear/server restart).
 # The hook queries these via GET /api/check-auto-allow.
-# For persistent rules, see settings.local.json (checked directly by the hook).
+# For persistent rules, see the 4-level rule system in permission_rules.py.
 session_auto_allow = {}
 
 
@@ -512,9 +513,7 @@ def zombie_cleanup_loop():
             for sid in dead:
                 del sessions[sid]
                 # Clear auto-allow rules
-                keys_to_remove = [k for k in session_auto_allow if k[0] == sid]
-                for k in keys_to_remove:
-                    del session_auto_allow[k]
+                session_auto_allow.pop(sid, None)
         if dead:
             print(f"[~] Cleaned up {len(dead)} zombie session(s): {dead}")
 
@@ -639,8 +638,35 @@ class WebUIHandler(BaseHTTPRequestHandler):
             params = parse_qs(parsed.query)
             sid = params.get("session_id", [""])[0]
             tname = params.get("tool_name", [""])[0]
-            result = (sid, tname) in session_auto_allow if sid and tname else False
-            self._respond_json({"auto_allow": result})
+            tool_input_str = params.get("tool_input", [""])[0]
+            try:
+                tool_input = json.loads(tool_input_str) if tool_input_str else {}
+            except (json.JSONDecodeError, ValueError):
+                tool_input = {}
+            session_rules = session_auto_allow.get(sid)
+            if session_rules and tname:
+                result = permission_rules.check_level(tname, tool_input, session_rules)
+                self._respond_json({
+                    "auto_allow": result == "allow",
+                    "auto_deny": result == "deny",
+                })
+            else:
+                self._respond_json({"auto_allow": False, "auto_deny": False})
+
+        elif path == "/api/permissions":
+            params = parse_qs(parsed.query)
+            project_dir = params.get("project_dir", [""])[0]
+            sid = params.get("session_id", [""])[0]
+            result = {
+                "repo": permission_rules.load_rules(permission_rules.repo_rules_path()),
+                "user": permission_rules.load_rules(permission_rules.user_rules_path()),
+            }
+            if project_dir:
+                result["project"] = permission_rules.load_rules(
+                    permission_rules.project_rules_path(project_dir))
+            if sid:
+                result["session"] = session_auto_allow.get(sid, {"rules": [], "smart_rules": {}})
+            self._respond_json(result)
 
         elif path == "/api/pending":
             # Legacy endpoint — scan .request.json files
@@ -740,9 +766,7 @@ class WebUIHandler(BaseHTTPRequestHandler):
                     evict = [k for k, v in sessions.items() if k != sid and v.get("terminal_id") == terminal_id]
                     for k in evict:
                         del sessions[k]
-                        keys_to_remove = [ak for ak in session_auto_allow if ak[0] == k]
-                        for ak in keys_to_remove:
-                            del session_auto_allow[ak]
+                        session_auto_allow.pop(k, None)
                     if evict:
                         print(f"[~] Evicted session(s) on terminal {terminal_id}: {evict}")
 
@@ -778,9 +802,7 @@ class WebUIHandler(BaseHTTPRequestHandler):
 
                 if source == "clear":
                     # Clear auto-allow rules
-                    keys_to_remove = [k for k in session_auto_allow if k[0] == sid]
-                    for k in keys_to_remove:
-                        del session_auto_allow[k]
+                    session_auto_allow.pop(sid, None)
                     # Clean up request files for this session
                     for fpath in glob.glob(os.path.join(QUEUE_DIR, "*.request.json")):
                         try:
@@ -809,10 +831,7 @@ class WebUIHandler(BaseHTTPRequestHandler):
 
             with sessions_lock:
                 sessions.pop(sid, None)
-                # Clear auto-allow
-                keys_to_remove = [k for k in session_auto_allow if k[0] == sid]
-                for k in keys_to_remove:
-                    del session_auto_allow[k]
+                session_auto_allow.pop(sid, None)
 
             # Clean up request files
             for fpath in glob.glob(os.path.join(QUEUE_DIR, "*.request.json")):
@@ -862,22 +881,31 @@ class WebUIHandler(BaseHTTPRequestHandler):
                 self.send_error(404, "Request not found")
                 return
 
-            # "always" → write to settings.local.json
+            # "always" → write to webui-allow.json (user-level by default)
             if decision == "always":
                 try:
                     with open(request_file) as f:
                         req_data = json.load(f)
-                    settings_file = req_data.get("settings_file", "")
-                    allow_patterns = body.get("allow_patterns") or []
-                    if not allow_patterns:
-                        allow_pattern = body.get("allow_pattern") or req_data.get("allow_pattern", "")
-                        if allow_pattern:
-                            allow_patterns = [allow_pattern]
-                    if settings_file:
-                        for pattern in allow_patterns:
-                            self._add_to_settings(settings_file, pattern)
-                except (json.JSONDecodeError, IOError):
-                    pass
+                    level = body.get("level", "user")
+                    # Accept structured rules from the new UI
+                    allow_rules = body.get("allow_rules") or []
+                    if not allow_rules:
+                        allow_rule = body.get("allow_rule") or req_data.get("allow_rule")
+                        if allow_rule:
+                            allow_rules = [allow_rule]
+                    project_dir = req_data.get("project_dir", "")
+                    if level == "project" and project_dir:
+                        target_path = permission_rules.project_rules_path(project_dir)
+                    elif level == "repo":
+                        target_path = permission_rules.repo_rules_path()
+                    else:
+                        target_path = permission_rules.user_rules_path()
+                    for rule in allow_rules:
+                        if isinstance(rule, dict) and rule.get("tool"):
+                            permission_rules.add_rule(target_path, rule)
+                            print(f"[+] Added rule to {level}: {rule}")
+                except (json.JSONDecodeError, IOError) as e:
+                    print(f"[!] Failed to save always-allow rule: {e}")
 
             response_file = os.path.join(QUEUE_DIR, f"{request_id}.response.json")
             resp_data = {"decision": decision}
@@ -912,8 +940,11 @@ class WebUIHandler(BaseHTTPRequestHandler):
                 return
 
             if sid and tool_name:
-                session_auto_allow[(sid, tool_name)] = True
-                print(f"[+] Session auto-allow: {tool_name} for session {sid}")
+                if sid not in session_auto_allow:
+                    session_auto_allow[sid] = {"rules": [], "smart_rules": {}}
+                rule = body.get("rule") or {"tool": tool_name, "action": "allow"}
+                session_auto_allow[sid]["rules"].append(rule)
+                print(f"[+] Session auto-allow: {rule} for session {sid}")
             if request_id:
                 resp_file = os.path.join(QUEUE_DIR, f"{request_id}.response.json")
                 req_file = os.path.join(QUEUE_DIR, f"{request_id}.request.json")
@@ -1018,9 +1049,7 @@ class WebUIHandler(BaseHTTPRequestHandler):
                 self.send_error(400, "Missing session_id")
                 return
             # Clear auto-allow
-            keys_to_remove = [k for k in session_auto_allow if k[0] == sid]
-            for k in keys_to_remove:
-                del session_auto_allow[k]
+            session_auto_allow.pop(sid, None)
             print(f"[*] Session reset (legacy): session={sid} source={source}")
             self._respond_json({"ok": True})
 
@@ -1032,10 +1061,125 @@ class WebUIHandler(BaseHTTPRequestHandler):
                 return
             with sessions_lock:
                 sessions.pop(sid, None)
-            keys_to_remove = [k for k in session_auto_allow if k[0] == sid]
-            for k in keys_to_remove:
-                del session_auto_allow[k]
+            session_auto_allow.pop(sid, None)
             print(f"[*] Session end (legacy): session={sid}")
+            self._respond_json({"ok": True})
+
+        # ── Permission management endpoints ──
+
+        elif path == "/api/permissions/add-rule":
+            body = self._read_json()
+            level = body.get("level", "user")
+            rule = body.get("rule", {})
+            project_dir = body.get("project_dir", "")
+            sid = body.get("session_id", "")
+            if not rule.get("tool"):
+                self.send_error(400, "Missing rule.tool")
+                return
+            if level == "session" and sid:
+                if sid not in session_auto_allow:
+                    session_auto_allow[sid] = {"rules": [], "smart_rules": {}}
+                session_auto_allow[sid]["rules"].append(rule)
+            else:
+                target = self._get_rules_path(level, project_dir)
+                permission_rules.add_rule(target, rule)
+            self._respond_json({"ok": True})
+
+        elif path == "/api/permissions/remove-rule":
+            body = self._read_json()
+            level = body.get("level", "user")
+            index = body.get("index", -1)
+            project_dir = body.get("project_dir", "")
+            sid = body.get("session_id", "")
+            if level == "session" and sid:
+                rules = session_auto_allow.get(sid, {}).get("rules", [])
+                if 0 <= index < len(rules):
+                    rules.pop(index)
+            else:
+                target = self._get_rules_path(level, project_dir)
+                permission_rules.remove_rule(target, index)
+            self._respond_json({"ok": True})
+
+        elif path == "/api/permissions/update-rule":
+            body = self._read_json()
+            level = body.get("level", "user")
+            index = body.get("index", -1)
+            rule = body.get("rule", {})
+            project_dir = body.get("project_dir", "")
+            sid = body.get("session_id", "")
+            if level == "session" and sid:
+                rules = session_auto_allow.get(sid, {}).get("rules", [])
+                if 0 <= index < len(rules):
+                    rules[index] = rule
+            else:
+                target = self._get_rules_path(level, project_dir)
+                permission_rules.update_rule(target, index, rule)
+            self._respond_json({"ok": True})
+
+        elif path == "/api/permissions/move-rule":
+            body = self._read_json()
+            from_level = body.get("from_level", "")
+            from_index = body.get("from_index", -1)
+            to_level = body.get("to_level", "")
+            project_dir = body.get("project_dir", "")
+            sid = body.get("session_id", "")
+            if from_level == "session" and sid:
+                # Move from session to file-based level
+                rules = session_auto_allow.get(sid, {}).get("rules", [])
+                if 0 <= from_index < len(rules):
+                    rule = rules.pop(from_index)
+                    target = self._get_rules_path(to_level, project_dir)
+                    permission_rules.add_rule(target, rule)
+            elif to_level == "session" and sid:
+                # Move from file-based level to session
+                source = self._get_rules_path(from_level, project_dir)
+                data = permission_rules.load_rules(source)
+                if 0 <= from_index < len(data["rules"]):
+                    rule = data["rules"][from_index]
+                    permission_rules.remove_rule(source, from_index)
+                    if sid not in session_auto_allow:
+                        session_auto_allow[sid] = {"rules": [], "smart_rules": {}}
+                    session_auto_allow[sid]["rules"].append(rule)
+            else:
+                source = self._get_rules_path(from_level, project_dir)
+                target = self._get_rules_path(to_level, project_dir)
+                permission_rules.move_rule(source, from_index, target)
+            self._respond_json({"ok": True})
+
+        elif path == "/api/permissions/set-smart-rule":
+            body = self._read_json()
+            level = body.get("level", "user")
+            key = body.get("key", "")
+            action = body.get("action", "allow")
+            project_dir = body.get("project_dir", "")
+            sid = body.get("session_id", "")
+            if not key:
+                self.send_error(400, "Missing key")
+                return
+            if level == "session" and sid:
+                if sid not in session_auto_allow:
+                    session_auto_allow[sid] = {"rules": [], "smart_rules": {}}
+                session_auto_allow[sid]["smart_rules"][key] = action
+            else:
+                target = self._get_rules_path(level, project_dir)
+                permission_rules.set_smart_rule(target, key, action)
+            self._respond_json({"ok": True})
+
+        elif path == "/api/permissions/remove-smart-rule":
+            body = self._read_json()
+            level = body.get("level", "user")
+            key = body.get("key", "")
+            project_dir = body.get("project_dir", "")
+            sid = body.get("session_id", "")
+            if not key:
+                self.send_error(400, "Missing key")
+                return
+            if level == "session" and sid:
+                sr = session_auto_allow.get(sid, {}).get("smart_rules", {})
+                sr.pop(key, None)
+            else:
+                target = self._get_rules_path(level, project_dir)
+                permission_rules.remove_smart_rule(target, key)
             self._respond_json({"ok": True})
 
         else:
@@ -1059,26 +1203,14 @@ class WebUIHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(html.encode())
 
-    def _add_to_settings(self, settings_file, pattern):
-        """Add an allow pattern to settings.local.json."""
-        try:
-            if os.path.exists(settings_file):
-                with open(settings_file) as f:
-                    settings = json.load(f)
-            else:
-                settings = {"permissions": {"allow": []}}
-            if "permissions" not in settings:
-                settings["permissions"] = {"allow": []}
-            if "allow" not in settings["permissions"]:
-                settings["permissions"]["allow"] = []
-            if pattern not in settings["permissions"]["allow"]:
-                settings["permissions"]["allow"].append(pattern)
-                with open(settings_file, "w") as f:
-                    json.dump(settings, f, indent=2)
-                    f.write("\n")
-                print(f"[+] Added to allowlist: {pattern}")
-        except (json.JSONDecodeError, IOError) as e:
-            print(f"[!] Failed to update settings: {e}")
+    def _get_rules_path(self, level, project_dir=""):
+        """Get the file path for a given rule level."""
+        if level == "repo":
+            return permission_rules.repo_rules_path()
+        elif level == "project" and project_dir:
+            return permission_rules.project_rules_path(project_dir)
+        else:
+            return permission_rules.user_rules_path()
 
 
 def _restore_sessions_from_terminal_mappings():

--- a/server.py
+++ b/server.py
@@ -914,6 +914,10 @@ class WebUIHandler(BaseHTTPRequestHandler):
             with open(response_file, "w") as f:
                 json.dump(resp_data, f)
 
+            # "always" added a new rule — recheck other pending requests
+            if decision == "always":
+                self._recheck_pending_requests()
+
             self._respond_json({"ok": True})
 
         elif path == "/api/session-allow":
@@ -951,6 +955,8 @@ class WebUIHandler(BaseHTTPRequestHandler):
                 if os.path.exists(req_file):
                     with open(resp_file, "w") as f:
                         json.dump({"decision": "allow"}, f)
+            # Recheck other pending requests that may now match the new session rule
+            self._recheck_pending_requests()
             self._respond_json({"ok": True})
 
         elif path == "/api/send-prompt":
@@ -1083,6 +1089,7 @@ class WebUIHandler(BaseHTTPRequestHandler):
             else:
                 target = self._get_rules_path(level, project_dir)
                 permission_rules.add_rule(target, rule)
+            self._recheck_pending_requests()
             self._respond_json({"ok": True})
 
         elif path == "/api/permissions/remove-rule":
@@ -1098,6 +1105,7 @@ class WebUIHandler(BaseHTTPRequestHandler):
             else:
                 target = self._get_rules_path(level, project_dir)
                 permission_rules.remove_rule(target, index)
+            self._recheck_pending_requests()
             self._respond_json({"ok": True})
 
         elif path == "/api/permissions/update-rule":
@@ -1114,6 +1122,7 @@ class WebUIHandler(BaseHTTPRequestHandler):
             else:
                 target = self._get_rules_path(level, project_dir)
                 permission_rules.update_rule(target, index, rule)
+            self._recheck_pending_requests()
             self._respond_json({"ok": True})
 
         elif path == "/api/permissions/move-rule":
@@ -1124,14 +1133,12 @@ class WebUIHandler(BaseHTTPRequestHandler):
             project_dir = body.get("project_dir", "")
             sid = body.get("session_id", "")
             if from_level == "session" and sid:
-                # Move from session to file-based level
                 rules = session_auto_allow.get(sid, {}).get("rules", [])
                 if 0 <= from_index < len(rules):
                     rule = rules.pop(from_index)
                     target = self._get_rules_path(to_level, project_dir)
                     permission_rules.add_rule(target, rule)
             elif to_level == "session" and sid:
-                # Move from file-based level to session
                 source = self._get_rules_path(from_level, project_dir)
                 data = permission_rules.load_rules(source)
                 if 0 <= from_index < len(data["rules"]):
@@ -1144,6 +1151,7 @@ class WebUIHandler(BaseHTTPRequestHandler):
                 source = self._get_rules_path(from_level, project_dir)
                 target = self._get_rules_path(to_level, project_dir)
                 permission_rules.move_rule(source, from_index, target)
+            self._recheck_pending_requests()
             self._respond_json({"ok": True})
 
         elif path == "/api/permissions/set-smart-rule":
@@ -1163,6 +1171,7 @@ class WebUIHandler(BaseHTTPRequestHandler):
             else:
                 target = self._get_rules_path(level, project_dir)
                 permission_rules.set_smart_rule(target, key, action)
+            self._recheck_pending_requests()
             self._respond_json({"ok": True})
 
         elif path == "/api/permissions/remove-smart-rule":
@@ -1180,6 +1189,7 @@ class WebUIHandler(BaseHTTPRequestHandler):
             else:
                 target = self._get_rules_path(level, project_dir)
                 permission_rules.remove_smart_rule(target, key)
+            self._recheck_pending_requests()
             self._respond_json({"ok": True})
 
         else:
@@ -1211,6 +1221,41 @@ class WebUIHandler(BaseHTTPRequestHandler):
             return permission_rules.project_rules_path(project_dir)
         else:
             return permission_rules.user_rules_path()
+
+    def _recheck_pending_requests(self):
+        """Re-evaluate pending permission requests against current rules.
+
+        Called after any rule mutation.  If a pending request now matches
+        an allow or deny rule, auto-write the response file so the hook
+        (which is polling) picks it up immediately.
+        """
+        for fpath in glob.glob(os.path.join(QUEUE_DIR, "*.request.json")):
+            resp_path = fpath.replace(".request.json", ".response.json")
+            if os.path.exists(resp_path):
+                continue
+            try:
+                with open(fpath) as f:
+                    req = json.load(f)
+            except (json.JSONDecodeError, IOError):
+                continue
+
+            tool_name = req.get("tool_name", "")
+            tool_input = req.get("tool_input", {})
+            project_dir = req.get("project_dir", "")
+            sid = str(req.get("session_id", ""))
+
+            session_rules = session_auto_allow.get(sid)
+            result = permission_rules.resolve(
+                tool_name, tool_input, project_dir, session_rules=session_rules)
+
+            if result == "allow":
+                with open(resp_path, "w") as f:
+                    json.dump({"decision": "allow"}, f)
+                print(f"[+] Auto-resolved pending request (allow): {tool_name}")
+            elif result == "deny":
+                with open(resp_path, "w") as f:
+                    json.dump({"decision": "deny", "message": "Denied by updated rule"}, f)
+                print(f"[-] Auto-resolved pending request (deny): {tool_name}")
 
 
 def _restore_sessions_from_terminal_mappings():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,3 +43,21 @@ def import_hook_module(name):
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
+
+
+@pytest.fixture
+def tmp_rules_file(tmp_path):
+    """Provide a factory that creates a temporary webui-allow.json file."""
+    def _write(rules=None, smart_rules=None, subdir=None):
+        if subdir:
+            path = tmp_path / subdir / "webui-allow.json"
+        else:
+            path = tmp_path / "webui-allow.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = {
+            "rules": rules or [],
+            "smart_rules": smart_rules or {},
+        }
+        path.write_text(json.dumps(data))
+        return str(path)
+    return _write

--- a/tests/test_permission_rules.py
+++ b/tests/test_permission_rules.py
@@ -1,317 +1,395 @@
-"""Tests for hook-permission-request.py — auto-allow logic, pattern matching, smart rules."""
+"""Tests for permission_rules.py — 4-level auto-allow rule engine."""
 
 import json
 import os
 import sys
-
-import importlib.util
 
 import pytest
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, PROJECT_ROOT)
 
-
-def _import_hook(name):
-    path = os.path.join(PROJECT_ROOT, f"{name}.py")
-    spec = importlib.util.spec_from_file_location(name.replace("-", "_"), path)
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
+import permission_rules as pr
 
 
-hook = _import_hook("hook-permission-request")
+# ── extract_bash_prefix ──
 
 
-# ── build_detail ──
+class TestExtractBashPrefix:
+    def test_simple_command(self):
+        assert pr.extract_bash_prefix("ls -la") == "ls"
+
+    def test_command_with_subcommand(self):
+        assert pr.extract_bash_prefix("git commit -m 'test'") == "git commit"
+
+    def test_command_with_path_arg(self):
+        # /path and .path args are skipped (treated as flags/paths, not subcommands)
+        assert pr.extract_bash_prefix("cat /tmp/foo.txt") == "cat"
+
+    def test_npm_install(self):
+        assert pr.extract_bash_prefix("npm install foo") == "npm install"
+
+    def test_no_subcommand(self):
+        assert pr.extract_bash_prefix("ls") == "ls"
+
+    def test_empty(self):
+        assert pr.extract_bash_prefix("") == ""
+
+    def test_multiline(self):
+        assert pr.extract_bash_prefix("git status\nmore stuff") == "git status"
+
+    def test_flag_only_args(self):
+        assert pr.extract_bash_prefix("grep -r -n pattern") == "grep pattern"
+
+    def test_dotfile_arg_skipped(self):
+        assert pr.extract_bash_prefix("cat ./foo.txt") == "cat"
 
 
-class TestBuildDetail:
-    def test_bash_simple_command(self):
-        detail, detail_sub, pattern, patterns = hook.build_detail(
-            "Bash", {"command": "git status"}
-        )
-        assert detail == "git status"
-        assert "Bash(git status:*)" in patterns
-
-    def test_bash_compound_command(self):
-        detail, detail_sub, pattern, patterns = hook.build_detail(
-            "Bash", {"command": "git add . && git commit -m 'test'"}
-        )
-        assert "Bash(git add:*)" in patterns
-        assert "Bash(git commit:*)" in patterns
-
-    def test_bash_pipe(self):
-        _, _, _, patterns = hook.build_detail(
-            "Bash", {"command": "cat foo.txt | grep bar"}
-        )
-        assert "Bash(cat foo.txt:*)" in patterns
-        assert "Bash(grep bar:*)" in patterns
-
-    def test_write_tool(self):
-        detail, _, pattern, _ = hook.build_detail(
-            "Write", {"file_path": "/tmp/test.txt"}
-        )
-        assert detail == "/tmp/test.txt"
-        assert pattern == "Write(/tmp/test.txt)"
-
-    def test_edit_tool(self):
-        detail, detail_sub, pattern, _ = hook.build_detail(
-            "Edit", {"file_path": "/tmp/test.txt", "old_string": "line1\nline2\nline3"}
-        )
-        assert detail == "/tmp/test.txt"
-        assert "line1" in detail_sub
-        assert pattern == "Edit(/tmp/test.txt)"
-
-    def test_webfetch_tool(self):
-        detail, detail_sub, pattern, _ = hook.build_detail(
-            "WebFetch", {"url": "https://example.com", "prompt": "read it"}
-        )
-        assert detail == "https://example.com"
-        assert detail_sub == "read it"
-        assert pattern == "WebFetch"
-
-    def test_websearch_tool(self):
-        detail, _, pattern, _ = hook.build_detail(
-            "WebSearch", {"query": "python testing"}
-        )
-        assert detail == "python testing"
-        assert pattern == "WebSearch"
-
-    def test_unknown_tool(self):
-        detail, _, pattern, _ = hook.build_detail(
-            "CustomTool", {"key1": "val1", "key2": "val2"}
-        )
-        assert "key1: val1" in detail
-        assert pattern == "CustomTool"
-
-    def test_ask_user_question(self):
-        detail, _, pattern, _ = hook.build_detail(
-            "AskUserQuestion",
-            {"questions": [{"question": "Continue?", "options": [{"label": "Yes", "description": "proceed"}]}]},
-        )
-        assert "Continue?" in detail
-        assert "Yes" in detail
-        assert pattern == "AskUserQuestion"
-
-    def test_exit_plan_mode(self):
-        detail, detail_sub, pattern, _ = hook.build_detail(
-            "ExitPlanMode",
-            {"plan": "My plan", "allowedPrompts": [{"tool": "Bash", "prompt": "ls"}]},
-        )
-        assert detail == "My plan"
-        assert "Bash" in detail_sub
-        assert pattern == "ExitPlanMode"
+# ── match_rule ──
 
 
-# ── _match_allow_pattern ──
+class TestMatchRule:
+    def test_bash_prefix_match(self):
+        rule = {"tool": "Bash", "prefix": "git commit", "action": "allow"}
+        assert pr.match_rule("Bash", {"command": "git commit -m 'test'"}, rule) is True
 
+    def test_bash_prefix_no_match(self):
+        rule = {"tool": "Bash", "prefix": "git commit", "action": "allow"}
+        assert pr.match_rule("Bash", {"command": "git push origin"}, rule) is False
 
-class TestMatchAllowPattern:
-    def test_exact_tool_name(self):
-        assert hook._match_allow_pattern("Read", "anything", "Read") is True
+    def test_bash_blanket(self):
+        rule = {"tool": "Bash", "action": "allow"}
+        assert pr.match_rule("Bash", {"command": "rm -rf /"}, rule) is True
+
+    def test_tool_name_match(self):
+        rule = {"tool": "Write", "action": "allow"}
+        assert pr.match_rule("Write", {"file_path": "/any/path"}, rule) is True
 
     def test_tool_name_mismatch(self):
-        assert hook._match_allow_pattern("Read", "anything", "Write") is False
+        rule = {"tool": "Write", "action": "allow"}
+        assert pr.match_rule("Read", {}, rule) is False
 
-    def test_glob_with_colon_star(self):
-        assert hook._match_allow_pattern("Bash", "git status", "Bash(git status:*)") is True
+    def test_mcp_prefix_normalized(self):
+        rule = {"tool": "Bash", "prefix": "git log", "action": "allow"}
+        assert pr.match_rule("mcp__acp__Bash", {"command": "git log --oneline"}, rule) is True
 
-    def test_glob_prefix_match(self):
-        assert hook._match_allow_pattern("Bash", "git commit -m 'test'", "Bash(git commit:*)") is True
-
-    def test_glob_no_match(self):
-        assert hook._match_allow_pattern("Bash", "rm -rf /", "Bash(git:*)") is False
-
-    def test_write_path_pattern(self):
-        assert hook._match_allow_pattern("Write", "/home/user/proj/foo.py", "Write(/home/user/proj/*)") is True
+    def test_write_with_path_prefix(self):
+        rule = {"tool": "Write", "prefix": "/home/user/proj/*", "action": "allow"}
+        assert pr.match_rule("Write", {"file_path": "/home/user/proj/src/main.py"}, rule) is True
 
     def test_write_path_outside(self):
-        assert hook._match_allow_pattern("Write", "/etc/passwd", "Write(/home/user/proj/*)") is False
+        rule = {"tool": "Write", "prefix": "/home/user/proj/*", "action": "allow"}
+        assert pr.match_rule("Write", {"file_path": "/etc/passwd"}, rule) is False
 
-    def test_empty_pattern(self):
-        assert hook._match_allow_pattern("Bash", "ls", "") is False
+    def test_edit_with_path_prefix(self):
+        rule = {"tool": "Edit", "prefix": "/home/user/proj/*", "action": "allow"}
+        assert pr.match_rule("Edit", {"file_path": "/home/user/proj/foo.py"}, rule) is True
+
+    def test_bash_prefix_partial_no_false_positive(self):
+        # "git com" should not match "git commit"
+        rule = {"tool": "Bash", "prefix": "gitcommando", "action": "allow"}
+        assert pr.match_rule("Bash", {"command": "git commit -m 'test'"}, rule) is False
+
+    def test_non_dict_tool_input(self):
+        rule = {"tool": "Bash", "prefix": "git", "action": "allow"}
+        assert pr.match_rule("Bash", "not a dict", rule) is False
 
 
-# ── _is_readonly_bash ──
+# ── is_readonly_bash ──
 
 
 class TestIsReadonlyBash:
     def test_simple_readonly(self):
-        assert hook._is_readonly_bash("ls -la") is True
-
-    def test_cat_file(self):
-        assert hook._is_readonly_bash("cat foo.txt") is True
-
-    def test_grep_search(self):
-        assert hook._is_readonly_bash("grep -r 'pattern' .") is True
+        assert pr.is_readonly_bash("ls -la") is True
 
     def test_git_log(self):
-        assert hook._is_readonly_bash("git log --oneline") is True
-
-    def test_git_status(self):
-        assert hook._is_readonly_bash("git status") is True
-
-    def test_git_diff(self):
-        assert hook._is_readonly_bash("git diff HEAD") is True
+        assert pr.is_readonly_bash("git log --oneline") is True
 
     def test_dangerous_rm(self):
-        assert hook._is_readonly_bash("rm -rf /tmp/foo") is False
-
-    def test_dangerous_curl(self):
-        assert hook._is_readonly_bash("curl https://example.com") is False
-
-    def test_dangerous_sudo(self):
-        assert hook._is_readonly_bash("sudo apt install foo") is False
+        assert pr.is_readonly_bash("rm -rf /tmp/foo") is False
 
     def test_compound_all_readonly(self):
-        assert hook._is_readonly_bash("ls -la && cat foo.txt | grep bar") is True
+        assert pr.is_readonly_bash("ls -la && cat foo.txt | grep bar") is True
 
     def test_compound_with_dangerous(self):
-        assert hook._is_readonly_bash("ls -la && rm foo.txt") is False
-
-    def test_pipe_all_readonly(self):
-        assert hook._is_readonly_bash("cat file | head -20 | wc -l") is True
+        assert pr.is_readonly_bash("ls -la && rm foo.txt") is False
 
     def test_git_push_not_readonly(self):
-        assert hook._is_readonly_bash("git push origin main") is False
-
-    def test_git_commit_not_readonly(self):
-        assert hook._is_readonly_bash("git commit -m 'msg'") is False
+        assert pr.is_readonly_bash("git push origin main") is False
 
     def test_sed_inplace_not_readonly(self):
-        assert hook._is_readonly_bash("sed -i 's/foo/bar/' file.txt") is False
+        assert pr.is_readonly_bash("sed -i 's/foo/bar/' file.txt") is False
 
-    def test_sed_without_inplace_is_readonly(self):
-        assert hook._is_readonly_bash("sed 's/foo/bar/' file.txt") is True
+    def test_sed_without_inplace(self):
+        assert pr.is_readonly_bash("sed 's/foo/bar/' file.txt") is True
 
-    def test_empty_command(self):
-        assert hook._is_readonly_bash("") is True
+    def test_empty(self):
+        assert pr.is_readonly_bash("") is True
 
-    def test_unknown_command_not_readonly(self):
-        assert hook._is_readonly_bash("my-custom-script.sh") is False
-
-    def test_semicolon_separator(self):
-        assert hook._is_readonly_bash("ls; cat foo") is True
-
-    def test_or_separator(self):
-        assert hook._is_readonly_bash("cat foo || echo fallback") is True
-
-    def test_echo_is_readonly(self):
-        assert hook._is_readonly_bash("echo hello") is True
-
-    def test_python_is_readonly(self):
-        assert hook._is_readonly_bash("python3 --version") is True
+    def test_unknown_command(self):
+        assert pr.is_readonly_bash("my-custom-script.sh") is False
 
 
-# ── _is_project_file ──
+# ── is_project_file ──
 
 
 class TestIsProjectFile:
-    def test_file_inside_project(self, tmp_path):
+    def test_inside(self, tmp_path):
         project = str(tmp_path / "project")
         os.makedirs(project)
-        filepath = os.path.join(project, "src", "main.py")
-        assert hook._is_project_file(filepath, project) is True
+        assert pr.is_project_file(os.path.join(project, "src", "main.py"), project) is True
 
-    def test_file_is_project_root(self, tmp_path):
+    def test_outside(self, tmp_path):
         project = str(tmp_path / "project")
         os.makedirs(project)
-        assert hook._is_project_file(project, project) is True
+        assert pr.is_project_file("/etc/passwd", project) is False
 
-    def test_file_outside_project(self, tmp_path):
+    def test_traversal(self, tmp_path):
         project = str(tmp_path / "project")
         os.makedirs(project)
-        assert hook._is_project_file("/etc/passwd", project) is False
+        assert pr.is_project_file(os.path.join(project, "..", "secret"), project) is False
 
-    def test_empty_path(self):
-        assert hook._is_project_file("", "/home/user") is False
-
-    def test_empty_project(self):
-        assert hook._is_project_file("/home/user/file.py", "") is False
-
-    def test_path_traversal(self, tmp_path):
-        project = str(tmp_path / "project")
-        os.makedirs(project)
-        outside = os.path.join(project, "..", "secret.txt")
-        assert hook._is_project_file(outside, project) is False
+    def test_empty(self):
+        assert pr.is_project_file("", "/home") is False
+        assert pr.is_project_file("/home/file", "") is False
 
 
-# ── check_auto_allow ──
+# ── check_level ──
 
 
-class TestCheckAutoAllow:
-    def test_matching_pattern(self, tmp_settings_file):
-        settings = tmp_settings_file(["Bash(git commit:*)"])
-        assert hook.check_auto_allow("Bash", "git commit -m 'test'", settings) is True
+class TestCheckLevel:
+    def test_rule_match(self):
+        config = {"rules": [{"tool": "Bash", "prefix": "git commit", "action": "allow"}], "smart_rules": {}}
+        assert pr.check_level("Bash", {"command": "git commit -m 'x'"}, config) == "allow"
 
-    def test_no_matching_pattern(self, tmp_settings_file):
-        settings = tmp_settings_file(["Bash(git commit:*)"])
-        assert hook.check_auto_allow("Bash", "rm -rf /", settings) is False
+    def test_rule_deny(self):
+        config = {"rules": [{"tool": "Bash", "prefix": "rm", "action": "deny"}], "smart_rules": {}}
+        assert pr.check_level("Bash", {"command": "rm -rf /"}, config) == "deny"
 
-    def test_blanket_tool_allow(self, tmp_settings_file):
-        settings = tmp_settings_file(["Read"])
-        assert hook.check_auto_allow("Read", "/any/path", settings) is True
+    def test_smart_rule_fallback(self):
+        config = {"rules": [], "smart_rules": {"readonly_tools": "allow"}}
+        assert pr.check_level("Read", {}, config) == "allow"
 
-    def test_missing_settings_file(self):
-        assert hook.check_auto_allow("Read", "x", "/nonexistent/settings.json") is False
+    def test_rule_before_smart(self):
+        # Rule says deny Write, smart says allow project_internal_edit
+        config = {
+            "rules": [{"tool": "Write", "action": "deny"}],
+            "smart_rules": {"project_internal_edit": "allow"},
+        }
+        assert pr.check_level("Write", {"file_path": "/proj/foo.py"}, config, "/proj") == "deny"
 
-    def test_empty_allow_list(self, tmp_settings_file):
-        settings = tmp_settings_file([])
-        assert hook.check_auto_allow("Read", "x", settings) is False
+    def test_no_match(self):
+        config = {"rules": [{"tool": "Bash", "prefix": "git", "action": "allow"}], "smart_rules": {}}
+        assert pr.check_level("Write", {"file_path": "/foo"}, config) is None
 
-    def test_compound_bash_all_allowed(self, tmp_settings_file):
-        settings = tmp_settings_file(["Bash(git:*)", "Bash(echo:*)"])
-        assert hook.check_auto_allow("Bash", "git status && echo done", settings) is True
+    def test_empty_config(self):
+        assert pr.check_level("Read", {}, None) is None
+        assert pr.check_level("Read", {}, {}) is None
 
-    def test_compound_bash_partial_not_allowed(self, tmp_settings_file):
-        settings = tmp_settings_file(["Bash(git:*)"])
-        assert hook.check_auto_allow("Bash", "git status && rm foo", settings) is False
+    def test_compound_bash_all_allowed(self):
+        config = {
+            "rules": [
+                {"tool": "Bash", "prefix": "git", "action": "allow"},
+                {"tool": "Bash", "prefix": "echo", "action": "allow"},
+            ],
+            "smart_rules": {},
+        }
+        assert pr.check_level("Bash", {"command": "git status && echo done"}, config) == "allow"
 
-    def test_write_path_pattern(self, tmp_settings_file):
-        settings = tmp_settings_file(["Write(/home/user/proj/*)"])
-        assert hook.check_auto_allow("Write", "/home/user/proj/src/main.py", settings) is True
+    def test_compound_bash_partial_deny(self):
+        config = {
+            "rules": [
+                {"tool": "Bash", "prefix": "git", "action": "allow"},
+                {"tool": "Bash", "prefix": "rm", "action": "deny"},
+            ],
+            "smart_rules": {},
+        }
+        assert pr.check_level("Bash", {"command": "git status && rm foo"}, config) == "deny"
+
+    def test_compound_bash_partial_no_match(self):
+        config = {
+            "rules": [{"tool": "Bash", "prefix": "git", "action": "allow"}],
+            "smart_rules": {},
+        }
+        # "rm foo" has no matching rule → whole compound returns None
+        assert pr.check_level("Bash", {"command": "git status && rm foo"}, config) is None
+
+    def test_smart_readonly_bash(self):
+        config = {"rules": [], "smart_rules": {"readonly_bash": "allow"}}
+        assert pr.check_level("Bash", {"command": "ls -la"}, config) == "allow"
+        assert pr.check_level("Bash", {"command": "rm foo"}, config) is None
+
+    def test_smart_project_internal_edit(self, tmp_path):
+        project = str(tmp_path)
+        config = {"rules": [], "smart_rules": {"project_internal_edit": "allow"}}
+        assert pr.check_level("Write", {"file_path": os.path.join(project, "f.py")}, config, project) == "allow"
+        assert pr.check_level("Write", {"file_path": "/etc/passwd"}, config, project) is None
+
+    def test_smart_readonly_bash_deny(self):
+        """Smart rule can also deny."""
+        config = {"rules": [], "smart_rules": {"readonly_bash": "deny"}}
+        assert pr.check_level("Bash", {"command": "ls -la"}, config) == "deny"
+
+
+# ── resolve (4-level priority) ──
+
+
+class TestResolve:
+    def test_session_overrides_project(self, tmp_path):
+        # Project says deny git commit, session says allow
+        proj_dir = str(tmp_path / "proj")
+        os.makedirs(os.path.join(proj_dir, ".claude"), exist_ok=True)
+        proj_rules = os.path.join(proj_dir, ".claude", "webui-allow.json")
+        with open(proj_rules, "w") as f:
+            json.dump({"rules": [{"tool": "Bash", "prefix": "git commit", "action": "deny"}], "smart_rules": {}}, f)
+
+        session = {"rules": [{"tool": "Bash", "prefix": "git commit", "action": "allow"}], "smart_rules": {}}
+        result = pr.resolve("Bash", {"command": "git commit -m 'x'"}, proj_dir, session_rules=session)
+        assert result == "allow"
+
+    def test_project_overrides_user(self, tmp_path, monkeypatch):
+        proj_dir = str(tmp_path / "proj")
+        os.makedirs(os.path.join(proj_dir, ".claude"), exist_ok=True)
+        proj_rules = os.path.join(proj_dir, ".claude", "webui-allow.json")
+        with open(proj_rules, "w") as f:
+            json.dump({"rules": [{"tool": "Write", "action": "deny"}], "smart_rules": {}}, f)
+
+        # Mock user_rules_path to use tmp
+        user_dir = str(tmp_path / "user_claude")
+        os.makedirs(user_dir, exist_ok=True)
+        user_file = os.path.join(user_dir, "webui-allow.json")
+        with open(user_file, "w") as f:
+            json.dump({"rules": [{"tool": "Write", "action": "allow"}], "smart_rules": {}}, f)
+        monkeypatch.setattr(pr, "user_rules_path", lambda: user_file)
+
+        result = pr.resolve("Write", {"file_path": "/any"}, proj_dir)
+        assert result == "deny"
+
+    def test_no_match_returns_none(self, tmp_path, monkeypatch):
+        proj_dir = str(tmp_path / "proj")
+        os.makedirs(proj_dir, exist_ok=True)
+        # Empty user and repo rules
+        monkeypatch.setattr(pr, "user_rules_path", lambda: str(tmp_path / "nonexistent"))
+        monkeypatch.setattr(pr, "repo_rules_path", lambda: str(tmp_path / "nonexistent2"))
+        result = pr.resolve("CustomTool", {}, proj_dir)
+        assert result is None
+
+    def test_repo_smart_rules_apply(self, tmp_path, monkeypatch):
+        proj_dir = str(tmp_path / "proj")
+        os.makedirs(proj_dir, exist_ok=True)
+        # No project or user rules
+        monkeypatch.setattr(pr, "user_rules_path", lambda: str(tmp_path / "nonexistent"))
+        # Repo has readonly_tools smart rule
+        repo_file = str(tmp_path / "repo-allow.json")
+        with open(repo_file, "w") as f:
+            json.dump({"rules": [], "smart_rules": {"readonly_tools": "allow"}}, f)
+        monkeypatch.setattr(pr, "repo_rules_path", lambda: repo_file)
+
+        result = pr.resolve("Read", {}, proj_dir)
+        assert result == "allow"
+
+    def test_deny_at_higher_level_blocks_lower_allow(self, tmp_path, monkeypatch):
+        proj_dir = str(tmp_path / "proj")
+        os.makedirs(os.path.join(proj_dir, ".claude"), exist_ok=True)
+        # Project denies WebFetch
+        proj_rules = os.path.join(proj_dir, ".claude", "webui-allow.json")
+        with open(proj_rules, "w") as f:
+            json.dump({"rules": [{"tool": "WebFetch", "action": "deny"}], "smart_rules": {}}, f)
+        # User allows WebFetch
+        user_file = str(tmp_path / "user-allow.json")
+        with open(user_file, "w") as f:
+            json.dump({"rules": [{"tool": "WebFetch", "action": "allow"}], "smart_rules": {}}, f)
+        monkeypatch.setattr(pr, "user_rules_path", lambda: user_file)
+        monkeypatch.setattr(pr, "repo_rules_path", lambda: str(tmp_path / "nonexistent"))
+
+        result = pr.resolve("WebFetch", {"url": "https://example.com"}, proj_dir)
+        assert result == "deny"
+
+
+# ── load_rules ──
+
+
+class TestLoadRules:
+    def test_valid_file(self, tmp_rules_file):
+        path = tmp_rules_file(
+            rules=[{"tool": "Bash", "prefix": "git", "action": "allow"}],
+            smart_rules={"readonly_tools": "allow"},
+        )
+        data = pr.load_rules(path)
+        assert len(data["rules"]) == 1
+        assert data["smart_rules"]["readonly_tools"] == "allow"
+
+    def test_missing_file(self):
+        data = pr.load_rules("/nonexistent/path.json")
+        assert data["rules"] == []
+        assert data["smart_rules"] == {}
 
     def test_invalid_json(self, tmp_path):
         bad = tmp_path / "bad.json"
         bad.write_text("not json")
-        assert hook.check_auto_allow("Read", "x", str(bad)) is False
+        data = pr.load_rules(str(bad))
+        assert data["rules"] == []
+
+    def test_empty_path(self):
+        data = pr.load_rules("")
+        assert data["rules"] == []
 
 
-# ── check_smart_auto_approve ──
+# ── CRUD ──
 
 
-class TestCheckSmartAutoApprove:
-    def test_readonly_tool(self):
-        assert hook.check_smart_auto_approve("Read", {}, "/any") is True
-        assert hook.check_smart_auto_approve("Glob", {}, "/any") is True
-        assert hook.check_smart_auto_approve("Grep", {}, "/any") is True
+class TestCRUD:
+    def test_add_rule(self, tmp_rules_file):
+        path = tmp_rules_file()
+        pr.add_rule(path, {"tool": "Bash", "prefix": "git commit", "action": "allow"})
+        data = pr.load_rules(path)
+        assert len(data["rules"]) == 1
+        assert data["rules"][0]["prefix"] == "git commit"
 
-    def test_readonly_bash(self):
-        assert hook.check_smart_auto_approve("Bash", {"command": "ls -la"}, "/any") is True
+    def test_remove_rule(self, tmp_rules_file):
+        path = tmp_rules_file(rules=[
+            {"tool": "Bash", "prefix": "git", "action": "allow"},
+            {"tool": "Write", "action": "allow"},
+        ])
+        pr.remove_rule(path, 0)
+        data = pr.load_rules(path)
+        assert len(data["rules"]) == 1
+        assert data["rules"][0]["tool"] == "Write"
 
-    def test_dangerous_bash(self):
-        assert hook.check_smart_auto_approve("Bash", {"command": "rm foo"}, "/any") is False
+    def test_update_rule(self, tmp_rules_file):
+        path = tmp_rules_file(rules=[{"tool": "Bash", "prefix": "git", "action": "allow"}])
+        pr.update_rule(path, 0, {"tool": "Bash", "prefix": "git", "action": "deny"})
+        data = pr.load_rules(path)
+        assert data["rules"][0]["action"] == "deny"
 
-    def test_write_inside_project(self, tmp_path):
-        project = str(tmp_path)
-        filepath = os.path.join(project, "src", "main.py")
-        assert hook.check_smart_auto_approve("Write", {"file_path": filepath}, project) is True
+    def test_move_rule(self, tmp_rules_file):
+        from_path = tmp_rules_file(rules=[
+            {"tool": "Bash", "prefix": "git", "action": "allow"},
+            {"tool": "Write", "action": "allow"},
+        ])
+        to_path = tmp_rules_file(subdir="dest")
+        pr.move_rule(from_path, 0, to_path)
+        from_data = pr.load_rules(from_path)
+        to_data = pr.load_rules(to_path)
+        assert len(from_data["rules"]) == 1
+        assert len(to_data["rules"]) == 1
+        assert to_data["rules"][0]["prefix"] == "git"
 
-    def test_write_outside_project(self, tmp_path):
-        project = str(tmp_path)
-        assert hook.check_smart_auto_approve("Write", {"file_path": "/etc/passwd"}, project) is False
+    def test_set_smart_rule(self, tmp_rules_file):
+        path = tmp_rules_file()
+        pr.set_smart_rule(path, "readonly_bash", "allow")
+        data = pr.load_rules(path)
+        assert data["smart_rules"]["readonly_bash"] == "allow"
 
-    def test_edit_inside_project(self, tmp_path):
-        project = str(tmp_path)
-        filepath = os.path.join(project, "foo.py")
-        assert hook.check_smart_auto_approve("Edit", {"file_path": filepath}, project) is True
+    def test_remove_smart_rule(self, tmp_rules_file):
+        path = tmp_rules_file(smart_rules={"readonly_bash": "allow", "readonly_tools": "allow"})
+        pr.remove_smart_rule(path, "readonly_bash")
+        data = pr.load_rules(path)
+        assert "readonly_bash" not in data["smart_rules"]
+        assert "readonly_tools" in data["smart_rules"]
 
-    def test_unknown_tool(self):
-        assert hook.check_smart_auto_approve("CustomTool", {}, "/any") is False
-
-    def test_bash_empty_command(self):
-        assert hook.check_smart_auto_approve("Bash", {"command": ""}, "/any") is False
-
-    def test_bash_string_input(self):
-        assert hook.check_smart_auto_approve("Bash", "not a dict", "/any") is False
+    def test_add_rule_creates_file(self, tmp_path):
+        path = str(tmp_path / "new_dir" / "webui-allow.json")
+        pr.add_rule(path, {"tool": "Read", "action": "allow"})
+        data = pr.load_rules(path)
+        assert len(data["rules"]) == 1


### PR DESCRIPTION
## Summary
- Replace writing `Bash(git commit:*)` patterns to Claude Code's `settings.local.json` with a WebUI-specific 4-level rule engine
- New `permission_rules.py` module: repo/user/project/session levels with priority resolution, simplified prefix matching, configurable smart rules, and CRUD operations
- New permissions management UI page accessible from dashboard header — view, add, delete, move rules between levels, toggle smart rules
- Updated permission card buttons to send structured rules instead of glob patterns
- "Always Allow" now defaults to writing user-level `~/.claude/webui-allow.json`

## Motivation
- Old pattern format was often inconsistent with Claude Code's native format, making rules useless
- Claude Code's upcoming "auto mode" reduces need for persistent rules in its config
- No way to manage/view/organize rules previously

## Key changes
- **permission_rules.py** (NEW): Core 4-level rule engine
- **auto-allow.json** (NEW): Repo-level defaults (readonly_tools, readonly_bash, project_internal_edit)
- **hook-permission-request.py**: Replaced Tier 1+2 with `permission_rules.resolve()`
- **server.py**: Restructured session_auto_allow, 7 new permission management API endpoints
- **frontend.py**: Updated permission cards, added permissions management page
- **channel_feishu.py**: Updated to use new rule format
- **tests**: 62 new tests for permission_rules module (112 total, all passing)

## Test plan
- [x] `python3 -m pytest tests/ -v` — 112 tests passing
- [ ] Start server, trigger permission request, verify "Always Allow" writes to `~/.claude/webui-allow.json`
- [ ] Open permissions management page from dashboard, verify 4 levels display correctly
- [ ] Add/delete/move rules between levels in the UI
- [ ] Verify deny rules block auto-approval
- [ ] Verify smart rule toggles work
- [ ] Test compound Bash commands (&&, |) with split allow

🤖 Generated with [Claude Code](https://claude.com/claude-code)